### PR TITLE
feat: Setup npm workspaces monorepo with build scripts

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,10 @@
+node_modules
+dist
+build
+coverage
+.tsonic
+out
+*.cs
+package-lock.json
+*.min.js
+*.min.css

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,7 @@
+{
+  "semi": true,
+  "trailingComma": "es5",
+  "singleQuote": false,
+  "printWidth": 80,
+  "tabWidth": 2
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -263,20 +263,29 @@ const emit = (ir: IrModule): string => { /* ... */ };
 ## Build Commands
 
 ```bash
-# Install dependencies (use pnpm)
-pnpm install
+# Install dependencies
+npm install
 
 # Build all packages
-pnpm build
+./scripts/build.sh
 
 # Run tests
-pnpm test
+npm test
 
 # Run specific test
-pnpm test -- --grep "pattern"
+npm test -- --grep "pattern"
 
 # Clean build artifacts
-pnpm clean
+./scripts/clean.sh
+
+# Clean everything including node_modules
+./scripts/clean.sh --all
+
+# Format code
+./scripts/format-all.sh
+
+# Lint code
+./scripts/lint-all.sh
 ```
 
 ## Git Workflow

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,59 @@
+import js from "@eslint/js";
+import typescript from "@typescript-eslint/eslint-plugin";
+import typescriptParser from "@typescript-eslint/parser";
+import globals from "globals";
+
+export default [
+  js.configs.recommended,
+  {
+    files: ["**/*.ts", "**/*.tsx"],
+    languageOptions: {
+      parser: typescriptParser,
+      parserOptions: {
+        ecmaVersion: 2021,
+        sourceType: "module",
+      },
+      globals: {
+        ...globals.node,
+        ...globals.es2021,
+      },
+    },
+    plugins: {
+      "@typescript-eslint": typescript,
+    },
+    rules: {
+      ...typescript.configs.recommended.rules,
+      quotes: ["error", "double", { avoidEscape: true, allowTemplateLiterals: true }],
+      "@typescript-eslint/no-explicit-any": "error",
+      "@typescript-eslint/explicit-module-boundary-types": "off",
+      "@typescript-eslint/no-unused-vars": ["error", { argsIgnorePattern: "^_" }],
+      "@typescript-eslint/no-non-null-assertion": "off",
+      "@typescript-eslint/consistent-type-definitions": ["error", "type"],
+      "no-var": "error",
+      "prefer-const": "error",
+      "no-let": "off", // We enforce const-only in code review
+      "no-param-reassign": "error",
+      "no-mutating-methods": "off", // Would need custom rule
+    },
+  },
+  {
+    files: ["**/*.js", "**/*.mjs"],
+    languageOptions: {
+      globals: {
+        ...globals.node,
+      },
+    },
+  },
+  {
+    ignores: [
+      "node_modules/**",
+      "dist/**",
+      "build/**",
+      "coverage/**",
+      ".tsonic/**",
+      "out/**",
+      "*.min.js",
+      "packages/runtime/*.cs",
+    ],
+  },
+];

--- a/package.json
+++ b/package.json
@@ -1,0 +1,57 @@
+{
+  "name": "@tsonic/monorepo",
+  "version": "0.0.1",
+  "description": "TypeScript to C# to NativeAOT compiler",
+  "type": "module",
+  "private": true,
+  "scripts": {
+    "build": "./scripts/build.sh",
+    "build:quick": "./scripts/build.sh --no-format",
+    "clean": "./scripts/clean.sh",
+    "clean:all": "./scripts/clean.sh --all",
+    "test": "npm test --workspaces",
+    "test:cli": "cd packages/cli && npm test",
+    "test:frontend": "cd packages/frontend && npm test",
+    "test:emitter": "cd packages/emitter && npm test",
+    "lint": "./scripts/lint-all.sh",
+    "lint:fix": "./scripts/lint-all.sh --fix",
+    "format": "./scripts/format-all.sh",
+    "format:check": "./scripts/format-all.sh --check",
+    "typecheck": "tsc --noEmit"
+  },
+  "workspaces": [
+    "packages/*"
+  ],
+  "devDependencies": {
+    "@eslint/js": "^9.37.0",
+    "@types/chai": "5.2.2",
+    "@types/mocha": "10.0.10",
+    "@types/node": "20.14.0",
+    "@typescript-eslint/eslint-plugin": "8.43.0",
+    "@typescript-eslint/parser": "8.43.0",
+    "chai": "5.3.3",
+    "eslint": "9.35.0",
+    "globals": "15.15.0",
+    "mocha": "11.7.2",
+    "prettier": "3.6.2",
+    "typescript": "5.9.2",
+    "typescript-eslint": "^8.45.0"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/tsoniclang/tsonic.git"
+  },
+  "keywords": [
+    "typescript",
+    "csharp",
+    "compiler",
+    "native-aot",
+    "dotnet",
+    "transpiler"
+  ],
+  "author": "Tsonic Project",
+  "license": "MIT"
+}

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# -------------------------------------------------------------------
+# build.sh – monorepo-aware build helper for Tsonic
+#
+# Flags:
+#   --clean      Clean build artifacts (dist, node_modules) and install dependencies
+#   --install    Force npm install without cleaning
+#   --no-format  Skip prettier formatting (faster builds during development)
+# -------------------------------------------------------------------
+set -euo pipefail
+
+# Change to the project root directory
+cd "$(dirname "$0")/.."
+
+echo "=== Building Tsonic ==="
+
+# Define the build order (dependencies first)
+PACKAGES=(
+  "runtime"       # Runtime library (no dependencies)
+  "frontend"      # TypeScript parser and IR builder
+  "emitter"       # C# code generator
+  "backend"       # dotnet CLI orchestration
+  "cli"           # CLI (depends on all others)
+)
+
+# 1 ▸ clean if --clean flag present
+if [[ "$*" == *--clean* ]]; then
+  ./scripts/clean.sh
+fi
+
+# 2 ▸ install dependencies if --clean or --install flag present
+if [[ "$*" == *--clean* || "$*" == *--install* ]]; then
+  if [[ "$*" == *--clean* ]]; then
+    # Clean already removed node_modules, so normal install
+    ./scripts/install-deps.sh
+  elif [[ "$*" == *--install* ]]; then
+    # Install without clean, so use --force
+    ./scripts/install-deps.sh --force
+  fi
+fi
+
+# 3 ▸ build each package that defines a build script, in order
+for pkg_name in "${PACKAGES[@]}"; do
+  pkg="packages/$pkg_name"
+  if [[ ! -f "$pkg/package.json" ]]; then
+    continue
+  fi
+  # Use node to check for build script instead of jq
+  if node -e "process.exit(require('./$pkg/package.json').scripts?.build ? 0 : 1)"; then
+    echo "Building $pkg…"
+    (cd "$pkg" && npm run build)
+  else
+    echo "No build script for $pkg, skipping"
+  fi
+done
+
+# 4 ▸ format all code unless --no-format is passed
+if [[ "$*" != *--no-format* ]]; then
+  echo "Running prettier…"
+  ./scripts/format-all.sh
+fi
+
+echo "=== Build completed ===="

--- a/scripts/clean.sh
+++ b/scripts/clean.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# -------------------------------------------------------------------
+# clean.sh – Clean build artifacts and node_modules across all packages
+# -------------------------------------------------------------------
+set -euo pipefail
+
+# Change to the project root directory
+cd "$(dirname "$0")/.."
+
+echo "=== Cleaning Tsonic build artifacts ==="
+
+# Define packages
+PACKAGES=(
+  "runtime"
+  "frontend"
+  "emitter"
+  "backend"
+  "cli"
+)
+
+# Clean dist directories in all packages
+for pkg_name in "${PACKAGES[@]}"; do
+  pkg="packages/$pkg_name"
+  if [[ -d "$pkg/dist" ]]; then
+    echo "Removing $pkg/dist"
+    rm -rf "$pkg/dist"
+  fi
+done
+
+# Clean any .tsbuildinfo files
+find . -name "*.tsbuildinfo" -type f -delete 2>/dev/null || true
+
+# Clean .tsonic build directory
+if [[ -d ".tsonic" ]]; then
+  echo "Removing .tsonic build directory"
+  rm -rf .tsonic
+fi
+
+# Clean output directory
+if [[ -d "out" ]]; then
+  echo "Removing out directory"
+  rm -rf out
+fi
+
+# Clean root node_modules if --all flag is passed
+if [[ "${1:-}" == "--all" ]]; then
+  if [[ -d "node_modules" ]]; then
+    echo "Removing root node_modules"
+    rm -rf node_modules
+  fi
+
+  # Clean node_modules from all packages
+  for pkg_name in "${PACKAGES[@]}"; do
+    pkg="packages/$pkg_name"
+    if [[ -d "$pkg/node_modules" ]]; then
+      echo "Removing $pkg/node_modules"
+      rm -rf "$pkg/node_modules"
+    fi
+  done
+
+  # Remove package-lock.json to ensure clean reinstall
+  if [[ -f "package-lock.json" ]]; then
+    echo "Removing package-lock.json"
+    rm -f package-lock.json
+  fi
+fi
+
+echo "=== Clean completed ===="

--- a/scripts/format-all.sh
+++ b/scripts/format-all.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Change to the project root directory
+cd "$(dirname "$0")/.."
+
+# Check for --check flag
+CHECK_FLAG=""
+if [[ "${1:-}" == "--check" ]]; then
+  CHECK_FLAG="--check"
+  echo "Checking formatting across all files..."
+else
+  echo "Formatting all files with prettier..."
+fi
+
+# Run prettier on all files
+if [ -n "$CHECK_FLAG" ]; then
+  ./node_modules/.bin/prettier $CHECK_FLAG \
+    "**/*.{js,jsx,ts,tsx,json,md,yml,yaml}" \
+    --ignore-path .prettierignore
+else
+  ./node_modules/.bin/prettier --write \
+    "**/*.{js,jsx,ts,tsx,json,md,yml,yaml}" \
+    --ignore-path .prettierignore
+fi
+
+echo "Formatting complete!"

--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# -------------------------------------------------------------------
+# install-deps.sh – Install dependencies for all packages in the monorepo
+#
+# Usage:
+#   ./scripts/install-deps.sh         # Install only if node_modules missing
+#   ./scripts/install-deps.sh --force # Force reinstall all dependencies
+# -------------------------------------------------------------------
+set -euo pipefail
+
+# Change to the project root directory
+cd "$(dirname "$0")/.."
+
+echo "=== Installing Tsonic Dependencies ==="
+
+# Define the package order (same as build order)
+PACKAGES=(
+  "runtime"
+  "frontend"
+  "emitter"
+  "backend"
+  "cli"
+)
+
+# Install root deps (once)
+if [[ ! -d node_modules || "$*" == *--force* ]]; then
+  echo "Installing root dependencies…"
+  npm install --legacy-peer-deps
+fi
+
+# Loop through every package in order
+for pkg_name in "${PACKAGES[@]}"; do
+  pkg="packages/$pkg_name"
+  if [[ ! -d "$pkg" ]]; then
+    echo "Package $pkg not found, skipping."
+    continue
+  fi
+  if [[ ! -d "$pkg/node_modules" || "$*" == *--force* ]]; then
+    echo "Installing deps in $pkg…"
+    (cd "$pkg" && npm install --legacy-peer-deps)
+  fi
+done
+
+echo "=== Dependency installation completed ===="

--- a/scripts/lint-all.sh
+++ b/scripts/lint-all.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# -------------------------------------------------------------------
+# lint-all.sh – Run ESLint across all packages
+# -------------------------------------------------------------------
+set -euo pipefail
+
+# Change to the project root directory
+cd "$(dirname "$0")/.."
+
+echo "=== Running ESLint across all packages ==="
+
+# Define packages to lint
+PACKAGES=(
+  "runtime"
+  "frontend"
+  "emitter"
+  "backend"
+  "cli"
+)
+
+# Check for --fix flag
+FIX_FLAG=""
+if [[ "${1:-}" == "--fix" ]]; then
+  FIX_FLAG="--fix"
+  echo "Running ESLint with auto-fix..."
+else
+  echo "Running ESLint (no auto-fix)..."
+fi
+
+# First ensure eslint is available
+if [[ ! -f "./node_modules/.bin/eslint" ]]; then
+  echo "ESLint not found. Please run: npm install"
+  exit 1
+fi
+
+# Run eslint on all packages
+ERRORS=0
+
+for pkg_name in "${PACKAGES[@]}"; do
+  pkg="packages/$pkg_name"
+
+  # Skip if package doesn't exist yet
+  if [[ ! -d "$pkg" ]]; then
+    continue
+  fi
+
+  # Check if src directory exists
+  if [[ ! -d "$pkg/src" ]]; then
+    echo "Skipping $pkg (no src directory)"
+    continue
+  fi
+
+  echo "Linting $pkg..."
+
+  if [ -n "$FIX_FLAG" ]; then
+    ./node_modules/.bin/eslint "$pkg/src/**/*.ts" "$pkg/src/**/*.tsx" $FIX_FLAG --config eslint.config.js || ERRORS=$?
+  else
+    ./node_modules/.bin/eslint "$pkg/src/**/*.ts" "$pkg/src/**/*.tsx" --config eslint.config.js || ERRORS=$?
+  fi
+done
+
+if [ $ERRORS -ne 0 ]; then
+  echo "=== ESLint found errors ==="
+  exit $ERRORS
+fi
+
+echo "=== ESLint completed successfully ===="

--- a/spec/13-implementation-plan.md
+++ b/spec/13-implementation-plan.md
@@ -11,17 +11,18 @@ This document outlines the step-by-step implementation plan for Tsonic, breaking
 **Goal:** Establish monorepo structure and basic tooling
 
 **Tasks:**
-1. Initialize monorepo with pnpm workspaces
+1. Initialize monorepo with npm workspaces
 2. Create package directories: cli, frontend, emitter, backend, runtime
-3. Setup TypeScript configuration for all packages
+3. Setup TypeScript configuration with base config
 4. Configure ESLint and Prettier
-5. Setup Jest for testing
+5. Create shell scripts for build orchestration
 6. Create basic package.json for each package
-7. Setup build scripts
+7. Setup test framework (Mocha/Chai)
 
 **Deliverables:**
-- Working monorepo structure
-- `pnpm install` and `pnpm build` work
+- Working monorepo structure with npm workspaces
+- Shell scripts: `build.sh`, `clean.sh`, `install-deps.sh`, `format-all.sh`, `lint-all.sh`
+- `npm install` and `./scripts/build.sh` work
 - Basic CI workflow (GitHub Actions)
 
 ### Phase 1: TypeScript Frontend

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,30 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2020"],
+    "strict": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "resolveJsonModule": true,
+    "allowJs": false,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "strictFunctionTypes": true,
+    "strictBindCallApply": true,
+    "strictPropertyInitialization": true,
+    "noImplicitThis": true,
+    "alwaysStrict": true,
+    "esModuleInterop": true
+  },
+  "exclude": ["node_modules", "dist", "build", "coverage", ".tsonic", "out"]
+}


### PR DESCRIPTION
- Replace pnpm with npm workspaces following tinqer's approach
- Add root package.json with npm workspaces configuration
- Create shell scripts for build orchestration:
  - build.sh: Builds packages in dependency order
  - clean.sh: Cleans build artifacts and node_modules
  - install-deps.sh: Installs dependencies for all packages
  - format-all.sh: Runs prettier across entire repo
  - lint-all.sh: Runs ESLint on all packages
- Add TypeScript base configuration with strict settings
- Configure ESLint with functional programming rules
- Setup Prettier for code formatting
- Update documentation to use npm instead of pnpm

Build order: runtime → frontend → emitter → backend → cli

This follows the exact monorepo approach used in tinqer with explicit build orchestration via shell scripts and npm workspaces.

🤖 Generated with Claude Code