### PR TITLE
refactor: Change Tsonic.Runtime to NuGet package assembly approach

### DIFF
--- a/CODING-STANDARDS.md
+++ b/CODING-STANDARDS.md
@@ -308,8 +308,14 @@ packages/
 │       ├── emit/              # IR → C#
 │       └── templates/         # C# code templates
 └── runtime/
-    ├── TsonicRuntime.cs       # C# runtime
-    └── lib.cs.d.ts           # .NET type declarations
+    ├── Tsonic.Runtime.csproj  # C# class library project
+    ├── TsonicRuntime.cs       # C# runtime implementation
+    ├── package.json           # npm package (for TypeScript declarations only)
+    └── lib/                   # .NET type declarations (per-namespace)
+        ├── System.d.ts
+        ├── System.IO.d.ts
+        ├── System.Collections.Generic.d.ts
+        └── ...
 ```
 
 ### File Naming

--- a/packages/runtime/Tsonic.Runtime.csproj
+++ b/packages/runtime/Tsonic.Runtime.csproj
@@ -1,0 +1,31 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <RootNamespace>Tsonic.Runtime</RootNamespace>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <LangVersion>latest</LangVersion>
+
+    <!-- NuGet Package Properties -->
+    <PackageId>Tsonic.Runtime</PackageId>
+    <Version>0.0.1</Version>
+    <Authors>Tsonic Project</Authors>
+    <Description>JavaScript/TypeScript runtime implementation for Tsonic compiler - provides exact JavaScript semantics in C#</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageProjectUrl>https://github.com/tsoniclang/tsonic</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/tsoniclang/tsonic.git</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PackageTags>typescript;csharp;compiler;runtime;native-aot</PackageTags>
+
+    <!-- Enable NativeAOT compatibility -->
+    <IsAotCompatible>true</IsAotCompatible>
+    <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- Required for JSON support -->
+    <PackageReference Include="System.Text.Json" Version="9.0.0" />
+  </ItemGroup>
+
+</Project>

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,14 +1,14 @@
 {
   "name": "@tsonic/runtime",
   "version": "0.0.1",
-  "description": "JavaScript runtime implementation in C# for Tsonic compiler",
+  "description": "Tsonic runtime - TypeScript declarations for .NET and Tsonic.Runtime types",
   "type": "module",
   "files": [
-    "TsonicRuntime.cs",
-    "lib.cs.d.ts"
+    "lib/"
   ],
   "scripts": {
-    "test": "echo 'Runtime tests run as part of backend tests'"
+    "build": "echo 'Runtime is a C# project - build with dotnet build Tsonic.Runtime.csproj'",
+    "test": "echo 'Runtime tests are C# tests - run with dotnet test'"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/spec/01-architecture.md
+++ b/spec/01-architecture.md
@@ -81,26 +81,30 @@ NativeAOT Executable
 **Key Modules**:
 
 - `dotnet.ts`: Execute dotnet commands (new, publish)
-- `files.ts`: Manage temporary build directories, copy runtime
+- `files.ts`: Manage temporary build directories
 
 **Workflow**:
 
 1. Create temporary project directory
-2. Generate minimal .csproj with NativeAOT settings
+2. Generate minimal .csproj with NativeAOT settings and Tsonic.Runtime package reference
 3. Copy generated C# files
-4. Copy Tsonic.Runtime.cs
-5. Generate Program.cs if needed
-6. Execute `dotnet publish`
-7. Copy output binary
+4. Generate Program.cs if needed
+5. Execute `dotnet publish` (restores Tsonic.Runtime from NuGet)
+6. Copy output binary
 
 ### 5. Runtime (`packages/runtime`)
 
 **Purpose**: JavaScript/TypeScript runtime implementation in C#
 
+**Structure**: C# class library project published as NuGet package
+
 **Key Files**:
 
-- `tsruntime.cs`: Core runtime (Array, String, console, Math, etc.)
+- `Tsonic.Runtime.csproj`: C# class library project file
+- `TsonicRuntime.cs`: Core runtime implementation (Array, String, console, Math, etc.)
 - `lib/System.d.ts`, `lib/System.IO.d.ts`, etc.: TypeScript declarations for .NET types (per-namespace)
+
+**Distribution**: Published as NuGet package `Tsonic.Runtime`, consumed via PackageReference in generated projects
 
 ## Intermediate Representation (IR)
 

--- a/spec/13-implementation-plan.md
+++ b/spec/13-implementation-plan.md
@@ -138,23 +138,27 @@ This document outlines the step-by-step implementation plan for Tsonic, breaking
 
 ### Phase 4: Tsonic Runtime Core
 
-**Goal:** Implement JavaScript runtime in C#
+**Goal:** Implement JavaScript runtime in C# as a class library
 
 **Package:** `packages/runtime`
 
+**Structure:** C# class library project (`.csproj`) compiled to assembly
+
 **Tasks:**
 
-1. Implement `Array<T>` with sparse array support
-2. Implement `String` wrapper with JS methods
-3. Implement `Number` wrapper with JS methods
+1. Create `Tsonic.Runtime.csproj` class library project
+2. Implement `Array<T>` with sparse array support
+3. Implement `String` static helpers with JS methods
 4. Implement `console` object
 5. Implement `Math` object
-6. Implement `Date` class
-7. Implement global functions (parseInt, parseFloat)
-8. Implement `JSON` object
+6. Implement global functions (parseInt, parseFloat)
+7. Implement `JSON` object
+8. Implement `Operators` class (typeof, instanceof)
+9. Configure project for NativeAOT compatibility
 
-**Key File:**
+**Key Files:**
 
+- `Tsonic.Runtime.csproj` - Class library project file
 - `TsonicRuntime.cs` - All runtime implementations
 
 **Note:** Generator helpers (for ergonomic `Next(value)` API) will be added in Phase 7 when generator support is implemented.
@@ -163,14 +167,15 @@ This document outlines the step-by-step implementation plan for Tsonic, breaking
 
 - Array sparse behavior
 - String method compatibility
-- Number method compatibility
 - Math function accuracy
-- Date conversions
+- JSON serialization/deserialization
+- typeof operator behavior
 
 **Deliverables:**
 
 - Complete runtime for basic JavaScript operations
-- NuGet package or embedded .cs file
+- Published as NuGet package `Tsonic.Runtime`
+- Can be consumed via PackageReference in generated projects
 
 ### Phase 5: .NET Backend
 
@@ -180,13 +185,12 @@ This document outlines the step-by-step implementation plan for Tsonic, breaking
 
 **Tasks:**
 
-1. Generate .csproj file
+1. Generate .csproj file with Tsonic.Runtime PackageReference
 2. Create temporary build directories
 3. Copy generated C# files
-4. Copy runtime file
-5. Generate Program.cs when needed
-6. Execute `dotnet publish` with NativeAOT
-7. Copy output binary
+4. Generate Program.cs when needed
+5. Execute `dotnet publish` with NativeAOT
+6. Copy output binary
 
 **Key Files:**
 


### PR DESCRIPTION
Update all documentation to specify that Tsonic.Runtime is distributed as a NuGet package rather than a source file copied during compilation.

Changes:
- Create Tsonic.Runtime.csproj for C# class library project
- Update runtime package.json to ship only TypeScript declarations
- Update build process specs to use PackageReference instead of copying
- Update architecture docs to describe NuGet package distribution
- Update implementation plan Phase 4 to describe class library structure
- Update coding standards to reflect new runtime directory structure

The runtime will be:
- Built as a C# class library (.csproj)
- Published to NuGet as Tsonic.Runtime package
- Consumed via <PackageReference> in generated projects
- Restored automatically by dotnet publish

Benefits: Standard .NET workflow, compiled once and reused, independent versioning, can be used by pure C# projects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)