### PR TITLE
docs: Reference generatedts tool for .NET type declarations

### DIFF
--- a/spec/01-architecture.md
+++ b/spec/01-architecture.md
@@ -102,9 +102,11 @@ NativeAOT Executable
 
 - `Tsonic.Runtime.csproj`: C# class library project file
 - `TsonicRuntime.cs`: Core runtime implementation (Array, String, console, Math, etc.)
-- `lib/System.d.ts`, `lib/System.IO.d.ts`, etc.: TypeScript declarations for .NET types (per-namespace)
+- `lib/System.d.ts`, `lib/System.IO.d.ts`, etc.: TypeScript declarations for .NET types (generated via `generatedts` tool)
 
 **Distribution**: Published as NuGet package `Tsonic.Runtime`, consumed via PackageReference in generated projects
+
+**Note**: The `.d.ts` files in `lib/` are generated using the `generatedts` tool (separate C# project in `../generatedts`) which uses reflection to analyze .NET assemblies and produce TypeScript declarations.
 
 ## Intermediate Representation (IR)
 

--- a/spec/13-implementation-plan.md
+++ b/spec/13-implementation-plan.md
@@ -283,19 +283,33 @@ This document outlines the step-by-step implementation plan for Tsonic, breaking
 
 **Tasks:**
 
-1. Create per-namespace .NET declaration files (System.d.ts, System.IO.d.ts, etc.)
-2. Implement .NET namespace detection
-3. Generate proper using statements
-4. Handle Task to Promise mapping
-5. Support common BCL types
-6. Auto-include declaration files in TypeScript program
+1. Generate .NET declaration files using the `generatedts` tool
+2. Populate `packages/runtime/lib/` with per-namespace `.d.ts` files
+3. Implement .NET namespace detection
+4. Generate proper using statements
+5. Handle Task to Promise mapping
+6. Support common BCL types
+7. Auto-include declaration files in TypeScript program
 
 **Key Files:**
 
-- `runtime/lib/System.d.ts` - Core .NET type declarations
-- `runtime/lib/System.IO.d.ts` - File I/O type declarations
-- `runtime/lib/System.Collections.Generic.d.ts` - Collection type declarations
-- Additional namespace files as needed
+- `runtime/lib/System.d.ts` - Core .NET type declarations (generated)
+- `runtime/lib/System.IO.d.ts` - File I/O type declarations (generated)
+- `runtime/lib/System.Collections.Generic.d.ts` - Collection type declarations (generated)
+- Additional namespace files as needed (generated)
+
+**Generation Tool:**
+
+The `.d.ts` files are generated using the `generatedts` tool (located in `../generatedts`):
+
+```bash
+cd ../generatedts
+dotnet run --project Src -- System.dll --out-dir ../tsonic/packages/runtime/lib/
+dotnet run --project Src -- System.IO.dll --out-dir ../tsonic/packages/runtime/lib/
+# etc. for each .NET assembly
+```
+
+See `../generatedts/README.md` for detailed usage.
 
 **Tests:**
 
@@ -309,6 +323,7 @@ This document outlines the step-by-step implementation plan for Tsonic, breaking
 - Can import and use .NET libraries
 - System.IO working
 - System.Text.Json working
+- Generated `.d.ts` files in `packages/runtime/lib/`
 
 ### Phase 9: Testing & Examples
 

--- a/spec/14-dotnet-declarations.md
+++ b/spec/14-dotnet-declarations.md
@@ -26,6 +26,32 @@ packages/runtime/lib/
 - Matches C# organization
 - Can be auto-generated from .NET metadata
 
+## Generation Tool
+
+The `.d.ts` files in `packages/runtime/lib/` are generated using the **`generatedts`** tool, a C# application that uses reflection to analyze .NET assemblies and produce TypeScript declarations.
+
+**Repository:** `../generatedts` (sibling directory)
+
+**Usage:**
+```bash
+# Generate declarations for a .NET assembly
+cd ../generatedts
+dotnet run --project Src -- /path/to/System.Text.Json.dll --out-dir ../tsonic/packages/runtime/lib/
+
+# Generate for multiple assemblies
+dotnet run --project Src -- System.IO.dll --out-dir ../tsonic/packages/runtime/lib/
+dotnet run --project Src -- System.Collections.Generic.dll --out-dir ../tsonic/packages/runtime/lib/
+```
+
+**Features:**
+- Automatically generates branded types for C# numerics (`int`, `decimal`, etc.)
+- Maps C# types to TypeScript equivalents (`Task<T>` → `Promise<T>`)
+- Filters out private/internal members
+- Supports namespace filtering and custom configuration
+- Generates proper TypeScript namespace declarations
+
+**See:** `../generatedts/README.md` for detailed usage and configuration options.
+
 ## Auto-Inclusion
 
 These declaration files are **automatically included** by the Tsonic compiler. No user configuration needed.


### PR DESCRIPTION
Add documentation about the generatedts tool (located in ../generatedts) which generates TypeScript declaration files from .NET assemblies using reflection.

Changes:
- spec/14-dotnet-declarations.md: Add "Generation Tool" section explaining how to use generatedts to populate packages/runtime/lib/ with .d.ts files
- spec/13-implementation-plan.md: Update Phase 8 to mention using generatedts tool for generating declaration files
- spec/01-architecture.md: Note that .d.ts files are generated via generatedts

The generatedts tool:
- Uses reflection to analyze .NET assemblies
- Generates per-namespace .d.ts files (System.d.ts, System.IO.d.ts, etc.)
- Handles type mappings (Task<T> → Promise<T>, T[] → ReadonlyArray<T>)
- Creates branded types for C# numerics (int, decimal, etc.)
- Filters out private/internal members

Usage: dotnet run --project Src -- Assembly.dll --out-dir ../tsonic/packages/runtime/lib/

🤖 Generated with [Claude Code](https://claude.com/claude-code)