### PR TITLE
feat: Implement metadata-driven override detection for .NET interop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -135,6 +135,9 @@ out/
 !packages/runtime/**/*.cs
 !packages/emitter/testcases/**/*.cs
 
+# Claude Code temp files
+.tests/
+
 # .NET build artifacts
 **/bin/
 **/obj/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,6 +52,18 @@ If you write mutable code, you MUST immediately rewrite it functionally.
 
 Automated scripts break syntax in unpredictable ways and destroy codebases.
 
+### TEMPORARY FILES
+
+**IMPORTANT**: Never create temporary files in the project root or package directories.
+
+- **ALWAYS** create temp files in `.tests/` directory
+- `.tests/` is gitignored for this purpose
+- Examples:
+  - Debug scripts: `.tests/debug-override.ts`
+  - Test data: `.tests/sample-input.json`
+  - Scratch files: `.tests/notes.md`
+- Delete temp files when no longer needed
+
 ## Session Startup
 
 ### First Steps When Starting a Session

--- a/packages/emitter/src/integration.test.ts
+++ b/packages/emitter/src/integration.test.ts
@@ -6,7 +6,7 @@
 import { describe, it } from "mocha";
 import { expect } from "chai";
 import * as ts from "typescript";
-import { buildIrModule } from "@tsonic/frontend";
+import { buildIrModule, DotnetMetadataRegistry } from "@tsonic/frontend";
 import { emitModule } from "./emitter.js";
 
 /**
@@ -61,6 +61,7 @@ const compileToCSharp = (
       rootNamespace: "Test",
     },
     sourceFiles: [sourceFile],
+    metadata: new DotnetMetadataRegistry(),
   };
 
   // Build IR

--- a/packages/emitter/src/statement-emitter.ts
+++ b/packages/emitter/src/statement-emitter.ts
@@ -425,6 +425,11 @@ const emitClassMember = (
         parts.push("static");
       }
 
+      // Override modifier (from metadata or TS base class detection)
+      if (member.isOverride) {
+        parts.push("override");
+      }
+
       if (member.isReadonly) {
         parts.push("readonly");
       }
@@ -465,10 +470,11 @@ const emitClassMember = (
       if (member.isStatic) {
         parts.push("static");
       }
-      // TODO: Implement proper override detection before emitting virtual/override modifiers.
-      // Cannot blindly emit override on all derived methods or virtual on all base methods.
-      // Requires symbol resolution to know if a method actually overrides a base member.
-      // For now, omit these modifiers to ensure generated C# compiles correctly.
+
+      // Override modifier (from metadata or TS base class detection)
+      if (member.isOverride) {
+        parts.push("override");
+      }
 
       if (member.isAsync) {
         parts.push("async");

--- a/packages/emitter/testcases/classes/inheritance/Inheritance.cs
+++ b/packages/emitter/testcases/classes/inheritance/Inheritance.cs
@@ -26,7 +26,7 @@ namespace TestCases.classes
             this.breed = breed;
             }
 
-        public string makeSound()
+        public override string makeSound()
             {
             return "Woof!";
             }

--- a/packages/frontend/src/dotnet-metadata.ts
+++ b/packages/frontend/src/dotnet-metadata.ts
@@ -1,0 +1,127 @@
+/**
+ * .NET Metadata Loader - Reads .metadata.json files to determine override behavior
+ */
+
+/**
+ * Metadata for a single .NET type member (method, property, etc.)
+ */
+export type DotnetMemberMetadata = {
+  readonly kind: "method" | "property" | "field" | "event";
+  readonly virtual?: boolean; // True if method is virtual/abstract
+  readonly sealed?: boolean; // True if method is sealed (cannot override)
+  readonly abstract?: boolean; // True if method is abstract
+};
+
+/**
+ * Metadata for a complete .NET type (class, interface, struct, etc.)
+ */
+export type DotnetTypeMetadata = {
+  readonly kind: "class" | "interface" | "struct" | "enum";
+  readonly members: Readonly<Record<string, DotnetMemberMetadata>>;
+};
+
+/**
+ * Complete metadata file structure
+ */
+export type DotnetMetadataFile = {
+  readonly types: Readonly<Record<string, DotnetTypeMetadata>>;
+};
+
+/**
+ * Registry of all loaded .NET metadata
+ * Maps fully-qualified type names to their metadata
+ */
+export class DotnetMetadataRegistry {
+  private readonly metadata = new Map<string, DotnetTypeMetadata>();
+
+  /**
+   * Load a metadata file and add its types to the registry
+   */
+  loadMetadataFile(_filePath: string, content: DotnetMetadataFile): void {
+    for (const [typeName, typeMetadata] of Object.entries(content.types)) {
+      this.metadata.set(typeName, typeMetadata);
+    }
+  }
+
+  /**
+   * Look up metadata for a .NET type by fully-qualified name
+   */
+  getTypeMetadata(qualifiedName: string): DotnetTypeMetadata | undefined {
+    return this.metadata.get(qualifiedName);
+  }
+
+  /**
+   * Look up metadata for a specific member of a .NET type
+   * @param qualifiedTypeName Fully-qualified type name (e.g., "System.IO.StringWriter")
+   * @param memberSignature Member signature (e.g., "ToString()" or "Write(string)")
+   */
+  getMemberMetadata(
+    qualifiedTypeName: string,
+    memberSignature: string
+  ): DotnetMemberMetadata | undefined {
+    const typeMetadata = this.metadata.get(qualifiedTypeName);
+    if (!typeMetadata) {
+      return undefined;
+    }
+    return typeMetadata.members[memberSignature];
+  }
+
+  /**
+   * Check if a member is virtual (can be overridden)
+   */
+  isVirtualMember(
+    qualifiedTypeName: string,
+    memberSignature: string
+  ): boolean {
+    const memberMetadata = this.getMemberMetadata(
+      qualifiedTypeName,
+      memberSignature
+    );
+    return memberMetadata?.virtual === true;
+  }
+
+  /**
+   * Check if a member is sealed (cannot be overridden)
+   */
+  isSealedMember(
+    qualifiedTypeName: string,
+    memberSignature: string
+  ): boolean {
+    const memberMetadata = this.getMemberMetadata(
+      qualifiedTypeName,
+      memberSignature
+    );
+    return memberMetadata?.sealed === true;
+  }
+
+  /**
+   * Get all loaded type names
+   */
+  getAllTypeNames(): readonly string[] {
+    return Array.from(this.metadata.keys());
+  }
+
+  /**
+   * Clear all loaded metadata
+   */
+  clear(): void {
+    this.metadata.clear();
+  }
+}
+
+/**
+ * Build a method signature string for metadata lookup
+ * Format: "MethodName(type1,type2,...)"
+ * @param methodName The method name
+ * @param parameterTypes Array of parameter type names (e.g., ["string", "number"])
+ * @returns Signature string for metadata lookup
+ */
+export const buildMethodSignature = (
+  methodName: string,
+  parameterTypes: readonly string[]
+): string => {
+  if (parameterTypes.length === 0) {
+    return `${methodName}()`;
+  }
+  return `${methodName}(${parameterTypes.join(",")})`;
+};

--- a/packages/frontend/src/index.ts
+++ b/packages/frontend/src/index.ts
@@ -25,6 +25,7 @@ export * from "./validator.js";
 export * from "./symbol-table.js";
 export * from "./dependency-graph.js";
 export * from "./ir/index.js";
+export * from "./dotnet-metadata.js";
 
 import { createProgram, TsonicProgram, CompilerOptions } from "./program.js";
 import { validateProgram } from "./validator.js";

--- a/packages/frontend/src/ir/builder.test.ts
+++ b/packages/frontend/src/ir/builder.test.ts
@@ -11,6 +11,7 @@ import {
   IrVariableDeclaration,
   IrClassDeclaration,
 } from "./types.js";
+import { DotnetMetadataRegistry } from "../dotnet-metadata.js";
 
 describe("IR Builder", () => {
   const createTestProgram = (source: string, fileName = "/test/test.ts") => {
@@ -47,6 +48,7 @@ describe("IR Builder", () => {
       checker: program.getTypeChecker(),
       options: { sourceRoot: "/test", rootNamespace: "TestApp", strict: true },
       sourceFiles: [sourceFile],
+      metadata: new DotnetMetadataRegistry(),
     };
   };
 

--- a/packages/frontend/src/ir/builder.ts
+++ b/packages/frontend/src/ir/builder.ts
@@ -14,7 +14,7 @@ import { TsonicProgram } from "../program.js";
 import { getNamespaceFromPath, getClassNameFromPath } from "../resolver.js";
 import { Result, ok, error } from "../types/result.js";
 import { Diagnostic, createDiagnostic } from "../types/diagnostic.js";
-import { convertStatement } from "./statement-converter.js";
+import { convertStatement, setMetadataRegistry } from "./statement-converter.js";
 import { convertExpression } from "./expression-converter.js";
 
 export type IrBuildOptions = {
@@ -31,6 +31,9 @@ export const buildIrModule = (
   options: IrBuildOptions
 ): Result<IrModule, Diagnostic> => {
   try {
+    // Set the metadata registry for this compilation
+    setMetadataRegistry(program.metadata);
+
     const namespace = getNamespaceFromPath(
       sourceFile.fileName,
       options.sourceRoot,

--- a/packages/frontend/src/ir/types.ts
+++ b/packages/frontend/src/ir/types.ts
@@ -122,6 +122,10 @@ export type IrMethodDeclaration = {
   readonly isAsync: boolean;
   readonly isGenerator: boolean;
   readonly accessibility: IrAccessibility;
+  /** True if this method overrides a virtual base class method (from metadata or TS base class) */
+  readonly isOverride?: boolean;
+  /** True if this method shadows a non-virtual base method (future: emit 'new' keyword) */
+  readonly isShadow?: boolean;
 };
 
 export type IrPropertyDeclaration = {
@@ -132,6 +136,10 @@ export type IrPropertyDeclaration = {
   readonly isStatic: boolean;
   readonly isReadonly: boolean;
   readonly accessibility: IrAccessibility;
+  /** True if this property overrides a virtual base class property (from metadata or TS base class) */
+  readonly isOverride?: boolean;
+  /** True if this property shadows a non-virtual base property (future: emit 'new' keyword) */
+  readonly isShadow?: boolean;
 };
 
 export type IrConstructorDeclaration = {

--- a/packages/frontend/src/validator.test.ts
+++ b/packages/frontend/src/validator.test.ts
@@ -13,6 +13,7 @@ import { expect } from "chai";
 import * as ts from "typescript";
 import { TsonicProgram } from "./program.js";
 import { validateProgram } from "./validator.js";
+import { DotnetMetadataRegistry } from "./dotnet-metadata.js";
 
 /**
  * Helper to create a test program from source code
@@ -66,6 +67,7 @@ const createTestProgram = (
       rootNamespace: "Test",
     },
     sourceFiles: [sourceFile],
+    metadata: new DotnetMetadataRegistry(),
   };
 };
 


### PR DESCRIPTION
Add support for metadata files (.metadata.json) to determine when to emit the `override` keyword for methods/properties that override .NET virtual methods.

**Implementation:**

- Created DotnetMetadataRegistry for storing .NET type metadata
- Added metadata loading during program creation (scans packages/runtime/lib/)
- Added isOverride and isShadow flags to IR method/property declarations
- Implemented override detection logic for both .NET and TypeScript base classes
- Updated emitter to emit 'override' keyword based on IR flags
- Used module-level singleton pattern for metadata registry (pragmatic approach)

**Files Changed:**

Frontend:
- packages/frontend/src/dotnet-metadata.ts (NEW): Metadata type system and registry
- packages/frontend/src/program.ts: Load metadata files, add to TsonicProgram
- packages/frontend/src/ir/types.ts: Add isOverride/isShadow to IR declarations
- packages/frontend/src/ir/statement-converter.ts: Override detection logic
- packages/frontend/src/ir/builder.ts: Set metadata registry at IR build start
- packages/frontend/src/index.ts: Export metadata types

Emitter:
- packages/emitter/src/statement-emitter.ts: Emit override keyword from IR flags
- packages/emitter/testcases/classes/inheritance/Inheritance.cs: Update golden test

Tests:
- packages/frontend/src/ir/builder.test.ts: Add metadata to mock programs
- packages/frontend/src/validator.test.ts: Add metadata to test programs
- packages/emitter/src/integration.test.ts: Add metadata to test setup

Project:
- .gitignore: Add .tests/ for temporary files
- CLAUDE.md: Document temp file convention

**Testing:**
- All 145 tests passing (8 backend + 83 emitter + 54 frontend)
- Inheritance golden test now correctly expects override keyword
- TypeScript base class override detection working
- Ready for .NET metadata files integration

🤖 Generated with [Claude Code](https://claude.com/claude-code)