### PR TITLE
feat: Static-first Tsonic - remove dynamic emission for NativeAOT

### DIFF
--- a/packages/emitter/src/types/dictionaries.ts
+++ b/packages/emitter/src/types/dictionaries.ts
@@ -1,0 +1,52 @@
+/**
+ * Dictionary type emission
+ */
+
+import { IrDictionaryType } from "@tsonic/frontend";
+import { EmitterContext, addUsing } from "../types.js";
+import { emitType } from "./emitter.js";
+
+/**
+ * Emit dictionary type as C# Dictionary<TKey, TValue>
+ *
+ * IrDictionaryType represents:
+ * - `{ [k: string]: T }` → Dictionary<string, T>
+ * - `Record<string, T>` → Dictionary<string, T>
+ *
+ * Note: Only string keys are supported (TSN7413). Number keys are rejected
+ * at validation time because TS number keys have string-ish semantics.
+ */
+export const emitDictionaryType = (
+  type: IrDictionaryType,
+  context: EmitterContext
+): [string, EmitterContext] => {
+  // Emit key type
+  const [keyTypeStr, ctx1] = emitDictionaryKeyType(type.keyType, context);
+
+  // Emit value type
+  const [valueTypeStr, ctx2] = emitType(type.valueType, ctx1);
+
+  // Add using for System.Collections.Generic
+  const ctx3 = addUsing(ctx2, "System.Collections.Generic");
+
+  return [`Dictionary<${keyTypeStr}, ${valueTypeStr}>`, ctx3];
+};
+
+/**
+ * Emit dictionary key type.
+ * Only string keys are supported (enforced by TSN7413).
+ * Non-string keys trigger ICE - validation should have caught them.
+ */
+const emitDictionaryKeyType = (
+  keyType: IrDictionaryType["keyType"],
+  context: EmitterContext
+): [string, EmitterContext] => {
+  if (keyType.kind === "primitiveType" && keyType.name === "string") {
+    return ["string", context];
+  }
+
+  // ICE: Only string keys allowed (enforced by TSN7413)
+  throw new Error(
+    `ICE: Non-string dictionary key type reached emitter - validation missed TSN7413. Got: ${keyType.kind}`
+  );
+};

--- a/packages/emitter/src/types/emitter.ts
+++ b/packages/emitter/src/types/emitter.ts
@@ -9,6 +9,7 @@ import { emitReferenceType } from "./references.js";
 import { emitArrayType } from "./arrays.js";
 import { emitFunctionType } from "./functions.js";
 import { emitObjectType } from "./objects.js";
+import { emitDictionaryType } from "./dictionaries.js";
 import { emitUnionType } from "./unions.js";
 import { emitIntersectionType } from "./intersections.js";
 import { emitLiteralType } from "./literals.js";
@@ -36,6 +37,9 @@ export const emitType = (
     case "objectType":
       return emitObjectType(type, context);
 
+    case "dictionaryType":
+      return emitDictionaryType(type, context);
+
     case "unionType":
       return emitUnionType(type, context);
 
@@ -46,9 +50,13 @@ export const emitType = (
       return emitLiteralType(type, context);
 
     case "anyType":
-      return ["dynamic", context];
+      // ICE: Frontend validation (TSN7401) should have caught this.
+      throw new Error(
+        "ICE: 'any' type reached emitter - validation missed TSN7401"
+      );
 
     case "unknownType":
+      // 'unknown' is a legitimate type - emit as nullable object
       return ["object?", context];
 
     case "voidType":
@@ -57,8 +65,12 @@ export const emitType = (
     case "neverType":
       return ["void", context];
 
-    default:
-      // Fallback for unhandled types
-      return ["object", context];
+    default: {
+      // ICE: All IR types should be handled explicitly
+      const exhaustiveCheck: never = type;
+      throw new Error(
+        `ICE: Unhandled IR type kind: ${(exhaustiveCheck as IrType).kind}`
+      );
+    }
   }
 };

--- a/packages/emitter/src/types/objects.ts
+++ b/packages/emitter/src/types/objects.ts
@@ -1,18 +1,27 @@
 /**
  * Object type emission
+ *
+ * IrObjectType represents anonymous object types like `{ x: number }`.
+ * These should be caught by frontend validation (TSN7403) and never reach the emitter.
+ *
+ * Named types (interfaces, type aliases, classes) become IrReferenceType instead.
  */
 
 import { IrType } from "@tsonic/frontend";
-import { EmitterContext, addUsing } from "../types.js";
+import { EmitterContext } from "../types.js";
 
 /**
- * Emit object types as dynamic
+ * Emit object types
+ *
+ * ICE: This should never be called. Frontend validation (TSN7403) should
+ * reject anonymous object types. If we reach here, validation has a gap.
  */
 export const emitObjectType = (
   _type: Extract<IrType, { kind: "objectType" }>,
-  context: EmitterContext
+  _context: EmitterContext
 ): [string, EmitterContext] => {
-  // For anonymous object types, we use dynamic or object
-  // In a more complete implementation, we might generate anonymous types
-  return ["dynamic", addUsing(context, "System")];
+  // ICE: Frontend validation (TSN7403) should have caught this.
+  throw new Error(
+    "ICE: Anonymous object type reached emitter - validation missed TSN7403"
+  );
 };

--- a/packages/emitter/src/types/parameters.ts
+++ b/packages/emitter/src/types/parameters.ts
@@ -27,17 +27,17 @@ export const emitTypeParameters = (
 
   for (const tp of typeParams) {
     if (tp.constraint) {
-      const [constraintStr, newContext] = emitType(
-        tp.constraint,
-        currentContext
-      );
-      currentContext = newContext;
-
-      // Handle structural constraints specially
+      // Handle structural constraints specially - they generate adapter interfaces
+      // Don't call emitType on objectType constraints (would trigger ICE)
       if (tp.isStructuralConstraint) {
         // Structural constraints generate interfaces - reference them
         whereClauses.push(`where ${tp.name} : __Constraint_${tp.name}`);
       } else {
+        const [constraintStr, newContext] = emitType(
+          tp.constraint,
+          currentContext
+        );
+        currentContext = newContext;
         whereClauses.push(`where ${tp.name} : ${constraintStr}`);
       }
     }

--- a/packages/frontend/src/ir/type-converter/orchestrator.ts
+++ b/packages/frontend/src/ir/type-converter/orchestrator.ts
@@ -3,7 +3,12 @@
  */
 
 import * as ts from "typescript";
-import { IrType, IrFunctionType, IrObjectType } from "../types.js";
+import {
+  IrType,
+  IrFunctionType,
+  IrObjectType,
+  IrDictionaryType,
+} from "../types.js";
 import { convertPrimitiveKeyword } from "./primitives.js";
 import { convertTypeReference } from "./references.js";
 import { convertArrayType } from "./arrays.js";
@@ -77,4 +82,4 @@ export { convertFunctionType } from "./functions.js";
 export { convertObjectType } from "./objects.js";
 
 // Export types
-export type { IrFunctionType, IrObjectType };
+export type { IrFunctionType, IrObjectType, IrDictionaryType };

--- a/packages/frontend/src/ir/type-converter/references.ts
+++ b/packages/frontend/src/ir/type-converter/references.ts
@@ -3,7 +3,7 @@
  */
 
 import * as ts from "typescript";
-import { IrType } from "../types.js";
+import { IrType, IrDictionaryType } from "../types.js";
 import { isPrimitiveTypeName, getPrimitiveType } from "./primitives.js";
 import { getParameterModifierRegistry } from "../../types/parameter-modifiers.js";
 
@@ -23,6 +23,18 @@ export const convertTypeReference = (
   // Check for primitive type names
   if (isPrimitiveTypeName(typeName)) {
     return getPrimitiveType(typeName);
+  }
+
+  // Check for Record<K, V> utility type → convert to IrDictionaryType
+  if (typeName === "Record" && node.typeArguments?.length === 2) {
+    const keyType = convertType(node.typeArguments[0]!, checker);
+    const valueType = convertType(node.typeArguments[1]!, checker);
+
+    return {
+      kind: "dictionaryType",
+      keyType,
+      valueType,
+    } as IrDictionaryType;
   }
 
   // Check if this is a parameter modifier type (ref/out/In) from @tsonic/types

--- a/packages/frontend/src/ir/types.ts
+++ b/packages/frontend/src/ir/types.ts
@@ -69,6 +69,7 @@ export type {
   IrArrayType,
   IrFunctionType,
   IrObjectType,
+  IrDictionaryType,
   IrUnionType,
   IrIntersectionType,
   IrLiteralType,

--- a/packages/frontend/src/ir/types/index.ts
+++ b/packages/frontend/src/ir/types/index.ts
@@ -77,6 +77,7 @@ export type {
   IrArrayType,
   IrFunctionType,
   IrObjectType,
+  IrDictionaryType,
   IrUnionType,
   IrIntersectionType,
   IrLiteralType,

--- a/packages/frontend/src/ir/types/ir-types.ts
+++ b/packages/frontend/src/ir/types/ir-types.ts
@@ -10,6 +10,7 @@ export type IrType =
   | IrArrayType
   | IrFunctionType
   | IrObjectType
+  | IrDictionaryType
   | IrUnionType
   | IrIntersectionType
   | IrLiteralType
@@ -45,6 +46,22 @@ export type IrFunctionType = {
 export type IrObjectType = {
   readonly kind: "objectType";
   readonly members: readonly IrInterfaceMember[];
+};
+
+/**
+ * Dictionary/map type for index signatures and Record<K, V>
+ *
+ * Examples:
+ * - `{ [k: string]: T }` → IrDictionaryType { keyType: string, valueType: T }
+ * - `Record<string, T>` → IrDictionaryType { keyType: string, valueType: T }
+ *
+ * Emits to C# Dictionary<TKey, TValue>.
+ * Access should be via indexer `d["key"]` (dot property access will fail in C#).
+ */
+export type IrDictionaryType = {
+  readonly kind: "dictionaryType";
+  readonly keyType: IrType;
+  readonly valueType: IrType;
 };
 
 export type IrUnionType = {

--- a/packages/frontend/src/program/index.ts
+++ b/packages/frontend/src/program/index.ts
@@ -2,7 +2,7 @@
  * Program - Public API
  */
 
-export type { CompilerOptions, TsonicProgram } from "./types.js";
+export type { CompilerOptions, TsonicProgram, RuntimeMode } from "./types.js";
 export { defaultTsConfig } from "./config.js";
 export { loadDotnetMetadata } from "./metadata.js";
 export { BindingRegistry, loadBindings } from "./bindings.js";

--- a/packages/frontend/src/program/types.ts
+++ b/packages/frontend/src/program/types.ts
@@ -6,6 +6,8 @@ import * as ts from "typescript";
 import { DotnetMetadataRegistry } from "../dotnet-metadata.js";
 import { BindingRegistry } from "./bindings.js";
 
+export type RuntimeMode = "js" | "dotnet";
+
 export type CompilerOptions = {
   readonly sourceRoot: string;
   readonly rootNamespace: string;
@@ -14,6 +16,13 @@ export type CompilerOptions = {
   readonly verbose?: boolean;
   /** Use TypeScript standard lib (Array, Promise, etc.) instead of noLib mode */
   readonly useStandardLib?: boolean;
+  /**
+   * Runtime mode:
+   * - "js": JS built-ins available via Tsonic.JSRuntime
+   * - "dotnet": Pure .NET mode, JS built-ins forbidden
+   * Defaults to "js"
+   */
+  readonly runtime?: RuntimeMode;
 };
 
 export type TsonicProgram = {

--- a/packages/frontend/src/types/diagnostic.ts
+++ b/packages/frontend/src/types/diagnostic.ts
@@ -32,6 +32,11 @@ export type DiagnosticCode =
   | "TSN7203" // Symbol keys not supported
   | "TSN7204" // Variadic generic interface not supported
   | "TSN7301" // Class cannot implement nominalized interface
+  // Static/AOT safety errors (TSN7401-TSN7499)
+  | "TSN7401" // 'any' type not supported - requires explicit type
+  | "TSN7403" // Object literal requires contextual nominal type
+  | "TSN7405" // Untyped lambda parameter - requires explicit type annotation
+  | "TSN7413" // Dictionary key must be string type
   // Metadata loading errors (TSN9001-TSN9018)
   | "TSN9001" // Metadata file not found
   | "TSN9002" // Failed to read metadata file

--- a/packages/frontend/src/validation/index.ts
+++ b/packages/frontend/src/validation/index.ts
@@ -7,4 +7,5 @@ export { validateImports, validateImportDeclaration } from "./imports.js";
 export { validateExports } from "./exports.js";
 export { validateUnsupportedFeatures } from "./features.js";
 export { validateGenerics } from "./generics.js";
+export { validateStaticSafety } from "./static-safety.js";
 export { hasExportModifier, getNodeLocation } from "./helpers.js";

--- a/packages/frontend/src/validation/orchestrator.ts
+++ b/packages/frontend/src/validation/orchestrator.ts
@@ -12,6 +12,7 @@ import { validateImports } from "./imports.js";
 import { validateExports } from "./exports.js";
 import { validateUnsupportedFeatures } from "./features.js";
 import { validateGenerics } from "./generics.js";
+import { validateStaticSafety } from "./static-safety.js";
 
 /**
  * Validate an entire Tsonic program
@@ -40,6 +41,7 @@ export const validateSourceFile = (
     validateExports,
     validateUnsupportedFeatures,
     validateGenerics,
+    validateStaticSafety,
   ];
 
   return validationFns.reduce(

--- a/packages/frontend/src/validation/static-safety.ts
+++ b/packages/frontend/src/validation/static-safety.ts
@@ -1,0 +1,267 @@
+/**
+ * Static Safety Validation
+ *
+ * Detects patterns that violate static typing requirements:
+ * - TSN7401: 'any' type usage
+ * - TSN7403: Object literal without contextual nominal type
+ * - TSN7405: Untyped function/arrow/lambda parameter
+ * - TSN7413: Dictionary key must be string type
+ *
+ * This ensures NativeAOT-compatible, predictable-performance output.
+ *
+ * Note: We intentionally do NOT validate JS built-in usage (arr.map, str.length)
+ * or dictionary dot-access patterns. These will fail naturally in C# if used
+ * incorrectly, which is an acceptable failure mode.
+ */
+
+import * as ts from "typescript";
+import { TsonicProgram } from "../program.js";
+import {
+  DiagnosticsCollector,
+  addDiagnostic,
+  createDiagnostic,
+} from "../types/diagnostic.js";
+import { getNodeLocation } from "./helpers.js";
+
+/**
+ * Validate a source file for static safety violations.
+ */
+export const validateStaticSafety = (
+  sourceFile: ts.SourceFile,
+  program: TsonicProgram,
+  collector: DiagnosticsCollector
+): DiagnosticsCollector => {
+  const checker = program.checker;
+
+  const visitor = (
+    node: ts.Node,
+    accCollector: DiagnosticsCollector
+  ): DiagnosticsCollector => {
+    let currentCollector = accCollector;
+
+    // TSN7401: Check for explicit 'any' type annotations
+    if (node.kind === ts.SyntaxKind.AnyKeyword) {
+      currentCollector = addDiagnostic(
+        currentCollector,
+        createDiagnostic(
+          "TSN7401",
+          "error",
+          "'any' type is not supported. Provide a concrete type, use 'unknown', or define a nominal type.",
+          getNodeLocation(sourceFile, node),
+          "Replace 'any' with a specific type like 'unknown', 'object', or a custom interface."
+        )
+      );
+    }
+
+    // TSN7401: Check for 'as any' type assertions
+    if (
+      ts.isAsExpression(node) &&
+      node.type.kind === ts.SyntaxKind.AnyKeyword
+    ) {
+      currentCollector = addDiagnostic(
+        currentCollector,
+        createDiagnostic(
+          "TSN7401",
+          "error",
+          "'as any' type assertion is not supported. Use a specific type assertion.",
+          getNodeLocation(sourceFile, node),
+          "Replace 'as any' with a specific type like 'as unknown' or 'as YourType'."
+        )
+      );
+    }
+
+    // TSN7405: Check for untyped function parameters
+    // Covers: function declarations, methods, constructors, arrow functions, function expressions
+    if (ts.isParameter(node) && !node.type) {
+      const parent = node.parent;
+      const isFunctionLike =
+        ts.isFunctionDeclaration(parent) ||
+        ts.isMethodDeclaration(parent) ||
+        ts.isConstructorDeclaration(parent) ||
+        ts.isArrowFunction(parent) ||
+        ts.isFunctionExpression(parent) ||
+        ts.isGetAccessorDeclaration(parent) ||
+        ts.isSetAccessorDeclaration(parent);
+
+      if (isFunctionLike) {
+        const paramName = ts.isIdentifier(node.name) ? node.name.text : "param";
+        currentCollector = addDiagnostic(
+          currentCollector,
+          createDiagnostic(
+            "TSN7405",
+            "error",
+            `Parameter '${paramName}' must have an explicit type annotation.`,
+            getNodeLocation(sourceFile, node),
+            "Add a type annotation to this parameter."
+          )
+        );
+      }
+    }
+
+    // TSN7403: Check for object literals without contextual nominal type
+    if (ts.isObjectLiteralExpression(node)) {
+      const contextualType = checker.getContextualType(node);
+
+      // Must have a contextual type that resolves to a nominal type or dictionary
+      if (
+        !contextualType ||
+        !isNominalOrDictionaryType(contextualType, checker)
+      ) {
+        currentCollector = addDiagnostic(
+          currentCollector,
+          createDiagnostic(
+            "TSN7403",
+            "error",
+            "Object literal requires a contextual nominal type (interface, type alias, or class). Anonymous object types are not supported.",
+            getNodeLocation(sourceFile, node),
+            "Add a type annotation like 'const x: MyInterface = { ... }' or define an interface/type alias."
+          )
+        );
+      }
+    }
+
+    // TSN7413: Check for non-string dictionary keys
+    // Record<K, V> where K is not string
+    if (ts.isTypeReferenceNode(node)) {
+      const typeName = node.typeName;
+      if (ts.isIdentifier(typeName) && typeName.text === "Record") {
+        const typeArgs = node.typeArguments;
+        if (typeArgs && typeArgs.length >= 1) {
+          const keyTypeNode = typeArgs[0]!;
+          if (!isStringKeyType(keyTypeNode)) {
+            currentCollector = addDiagnostic(
+              currentCollector,
+              createDiagnostic(
+                "TSN7413",
+                "error",
+                "Dictionary key type must be 'string'. Non-string key types are not supported for NativeAOT compatibility.",
+                getNodeLocation(sourceFile, keyTypeNode),
+                "Use Record<string, V> instead of Record<number, V> or other key types."
+              )
+            );
+          }
+        }
+      }
+    }
+
+    // TSN7413: Check for non-string index signatures
+    // { [k: number]: V } is not allowed
+    if (ts.isIndexSignatureDeclaration(node)) {
+      const keyParam = node.parameters[0];
+      if (keyParam?.type && !isStringKeyType(keyParam.type)) {
+        currentCollector = addDiagnostic(
+          currentCollector,
+          createDiagnostic(
+            "TSN7413",
+            "error",
+            "Index signature key type must be 'string'. Non-string key types are not supported for NativeAOT compatibility.",
+            getNodeLocation(sourceFile, keyParam.type),
+            "Use { [key: string]: V } instead of { [key: number]: V }."
+          )
+        );
+      }
+    }
+
+    // Continue visiting children
+    ts.forEachChild(node, (child) => {
+      currentCollector = visitor(child, currentCollector);
+    });
+
+    return currentCollector;
+  };
+
+  return visitor(sourceFile, collector);
+};
+
+/**
+ * Check if a contextual type is a nominal type (interface, type alias, class)
+ * or a dictionary type that we can emit.
+ *
+ * Returns false for anonymous object types like `{ x: number }` without a name.
+ */
+const isNominalOrDictionaryType = (
+  type: ts.Type,
+  checker: ts.TypeChecker
+): boolean => {
+  // Check if it's a dictionary type (Record<K,V> or index signature)
+  if (isTsDictionaryType(type)) {
+    return true;
+  }
+
+  // Check if the type has a symbol with a declaration (named type)
+  const symbol = type.getSymbol() ?? type.aliasSymbol;
+  if (symbol) {
+    const declarations = symbol.getDeclarations();
+    if (declarations && declarations.length > 0) {
+      const decl = declarations[0]!;
+      // Accept: interface, type alias, class
+      if (
+        ts.isInterfaceDeclaration(decl) ||
+        ts.isTypeAliasDeclaration(decl) ||
+        ts.isClassDeclaration(decl)
+      ) {
+        return true;
+      }
+    }
+  }
+
+  // Check for primitive types (allowed)
+  if (
+    type.flags & ts.TypeFlags.String ||
+    type.flags & ts.TypeFlags.Number ||
+    type.flags & ts.TypeFlags.Boolean ||
+    type.flags & ts.TypeFlags.Null ||
+    type.flags & ts.TypeFlags.Undefined ||
+    type.flags & ts.TypeFlags.Void
+  ) {
+    return true;
+  }
+
+  // Check for array types (allowed)
+  if (checker.isArrayType(type) || checker.isTupleType(type)) {
+    return true;
+  }
+
+  return false;
+};
+
+/**
+ * Check if a type is a TS dictionary type (Record<K,V> or index signature).
+ *
+ * TS dictionary types:
+ * - Record<string, T> → has aliasSymbol named "Record"
+ * - { [k: string]: T } → has string index signature
+ */
+const isTsDictionaryType = (type: ts.Type): boolean => {
+  // Check for Record<K,V> utility type
+  if (type.aliasSymbol?.name === "Record") {
+    return true;
+  }
+
+  // Check for index signature type like { [k: string]: T }
+  const stringIndexType = type.getStringIndexType();
+  const numberIndexType = type.getNumberIndexType();
+
+  return !!(stringIndexType || numberIndexType);
+};
+
+/**
+ * Check if a type node represents a string key type.
+ * Only `string` keyword is allowed for dictionary keys.
+ */
+const isStringKeyType = (typeNode: ts.TypeNode): boolean => {
+  // Direct string keyword
+  if (typeNode.kind === ts.SyntaxKind.StringKeyword) {
+    return true;
+  }
+
+  // Type reference to "string"
+  if (ts.isTypeReferenceNode(typeNode)) {
+    const typeName = typeNode.typeName;
+    if (ts.isIdentifier(typeName) && typeName.text === "string") {
+      return true;
+    }
+  }
+
+  return false;
+};


### PR DESCRIPTION
Remove all C# `dynamic` emission to ensure NativeAOT compatibility. Frontend validation is now the source of truth for AOT-unsafe patterns, and emitter throws ICE if invalid IR reaches it.

Key changes:

IR:
- Add IrDictionaryType for Record<K,V> and index signatures
- Convert Record<string, T> and { [k: string]: T } to IrDictionaryType

Frontend validation (static-safety.ts):
- TSN7401: Ban `any` type (would require DLR)
- TSN7403: Object literal must have contextual nominal type
- TSN7405: Untyped function parameters banned
- TSN7413: Dictionary key must be string (TS number keys are string-ish)

Emitter:
- Dictionary type emission: Dictionary<string, TValue> only
- Dictionary literal emission with C# string escaping
- Arrow function return type inference from TS checker
- ICE guards for anyType, objectType, untyped params, non-string keys
- Exhaustive type switch with `never` guard

Design decisions:
- TSN7410/TSN7412 intentionally not implemented (C# handles naturally)
- String-only dictionary keys (use CLR Dictionary<int,T> if needed)
- Arrow return types inferred if not explicit

Test coverage:
- 17 validation tests for TSN7401/7403/7405/7413
- 2 regression tests for key escaping and arrow inference

🤖 Generated with [Claude Code](https://claude.com/claude-code)