### PR TITLE
feat: Add import-driven .NET namespace resolution

### DIFF
--- a/npm/tsonic/package.json
+++ b/npm/tsonic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tsonic/tsonic",
-  "version": "0.1.2",
+  "version": "0.1.10",
   "description": "TypeScript to C# to NativeAOT compiler",
   "type": "module",
   "bin": {

--- a/packages/cli/src/cli/help.ts
+++ b/packages/cli/src/cli/help.ts
@@ -39,15 +39,15 @@ EMIT/BUILD/RUN OPTIONS:
 
 PROJECT INIT OPTIONS:
   --runtime <mode>          Runtime mode: js (default) or dotnet
-  --skip-types              Skip installing @tsonic/dotnet-types
-  --types-version <ver>     Version of @tsonic/dotnet-types to install
+  --skip-types              Skip installing type declarations
+  --types-version <ver>     Version of type declarations to install
 
 EXAMPLES:
   tsonic project init
   tsonic project init --runtime dotnet
-  tsonic emit src/main.ts
-  tsonic build src/main.ts --rid linux-x64
-  tsonic run src/main.ts -- --arg1 value1
+  tsonic emit src/app.ts
+  tsonic build src/app.ts --rid linux-x64
+  tsonic run src/app.ts -- --arg1 value1
 
 LEARN MORE:
   Documentation: https://tsonic.dev/docs

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -161,8 +161,13 @@ export const resolveConfig = (
     config.sourceRoot ??
     (entryPoint ? dirname(entryPoint) : "src");
 
-  // Default type roots: node_modules/@tsonic/dotnet-types/types
-  const defaultTypeRoots = ["node_modules/@tsonic/dotnet-types/types"];
+  // Default type roots based on runtime mode
+  // Only ambient globals packages need typeRoots - explicit import packages are resolved normally
+  const runtime = config.runtime ?? "js";
+  const defaultTypeRoots =
+    runtime === "js"
+      ? ["node_modules/@tsonic/js-globals"]
+      : ["node_modules/@tsonic/dotnet-globals"];
   const typeRoots = config.dotnet?.typeRoots ?? defaultTypeRoots;
 
   // Merge libraries from config and CLI

--- a/packages/emitter/src/golden.test.ts
+++ b/packages/emitter/src/golden.test.ts
@@ -29,8 +29,6 @@ try {
   if (scenarios.length === 0) {
     console.warn("⚠️  No golden test cases found in testcases/");
   } else {
-    console.log(`📋 Discovered ${scenarios.length} golden test case(s)`);
-
     const tree = buildDescribeTree(scenarios);
     if (tree) {
       registerNode(tree);

--- a/packages/emitter/src/integration.test.ts
+++ b/packages/emitter/src/integration.test.ts
@@ -10,6 +10,7 @@ import {
   buildIrModule,
   DotnetMetadataRegistry,
   BindingRegistry,
+  createDotNetImportResolver,
 } from "@tsonic/frontend";
 import { emitModule } from "./emitter.js";
 
@@ -67,6 +68,7 @@ const compileToCSharp = (
     sourceFiles: [sourceFile],
     metadata: new DotnetMetadataRegistry(),
     bindings: new BindingRegistry(),
+    dotnetResolver: createDotNetImportResolver("/test"),
   };
 
   // Build IR

--- a/packages/frontend/src/graph/extraction/imports.ts
+++ b/packages/frontend/src/graph/extraction/imports.ts
@@ -23,7 +23,8 @@ export const extractImport = (
   const result = resolveImport(
     specifier,
     sourceFile.fileName,
-    program.options.sourceRoot
+    program.options.sourceRoot,
+    program.dotnetResolver
   );
 
   const importedNames: { readonly name: string; readonly alias?: string }[] =
@@ -67,7 +68,7 @@ export const extractImport = (
           : "node_module",
       specifier,
       resolvedPath: result.value.resolvedPath || undefined,
-      namespace: result.value.isDotNet ? specifier : undefined,
+      namespace: result.value.resolvedNamespace,
       importedNames,
     };
   }

--- a/packages/frontend/src/ir/binding-resolution.test.ts
+++ b/packages/frontend/src/ir/binding-resolution.test.ts
@@ -9,6 +9,7 @@ import { buildIrModule } from "./builder.js";
 import { DotnetMetadataRegistry } from "../dotnet-metadata.js";
 import { BindingRegistry } from "../program/bindings.js";
 import { IrIdentifierExpression } from "./types.js";
+import { createDotNetImportResolver } from "../resolver/dotnet-import-resolver.js";
 
 describe("Binding Resolution in IR", () => {
   const createTestProgram = (
@@ -51,6 +52,7 @@ describe("Binding Resolution in IR", () => {
       sourceFiles: [sourceFile],
       metadata: new DotnetMetadataRegistry(),
       bindings: bindings || new BindingRegistry(),
+      dotnetResolver: createDotNetImportResolver("/test"),
     };
   };
 

--- a/packages/frontend/src/ir/builder/orchestrator.ts
+++ b/packages/frontend/src/ir/builder/orchestrator.ts
@@ -41,7 +41,11 @@ export const buildIrModule = (
     );
     const className = getClassNameFromPath(sourceFile.fileName);
 
-    const imports = extractImports(sourceFile, program.checker);
+    const imports = extractImports(
+      sourceFile,
+      program.checker,
+      program.dotnetResolver
+    );
     const exports = extractExports(sourceFile, program.checker);
     const statements = extractStatements(sourceFile, program.checker);
 

--- a/packages/frontend/src/ir/hierarchical-bindings-e2e.test.ts
+++ b/packages/frontend/src/ir/hierarchical-bindings-e2e.test.ts
@@ -9,6 +9,7 @@ import * as ts from "typescript";
 import { buildIrModule } from "./builder.js";
 import { DotnetMetadataRegistry } from "../dotnet-metadata.js";
 import { BindingRegistry } from "../program/bindings.js";
+import { createDotNetImportResolver } from "../resolver/dotnet-import-resolver.js";
 
 describe("Hierarchical Bindings End-to-End", () => {
   it("should resolve hierarchical bindings in IR for member access chain", () => {
@@ -90,6 +91,7 @@ describe("Hierarchical Bindings End-to-End", () => {
       sourceFiles: [sourceFile],
       metadata: new DotnetMetadataRegistry(),
       bindings,
+      dotnetResolver: createDotNetImportResolver("/test"),
     };
 
     // Build IR

--- a/packages/frontend/src/program/types.ts
+++ b/packages/frontend/src/program/types.ts
@@ -5,6 +5,7 @@
 import * as ts from "typescript";
 import { DotnetMetadataRegistry } from "../dotnet-metadata.js";
 import { BindingRegistry } from "./bindings.js";
+import { DotNetImportResolver } from "../resolver/dotnet-import-resolver.js";
 
 export type RuntimeMode = "js" | "dotnet";
 
@@ -32,4 +33,6 @@ export type TsonicProgram = {
   readonly sourceFiles: readonly ts.SourceFile[];
   readonly metadata: DotnetMetadataRegistry;
   readonly bindings: BindingRegistry;
+  /** Resolver for .NET namespace imports (import-driven discovery) */
+  readonly dotnetResolver: DotNetImportResolver;
 };

--- a/packages/frontend/src/resolver.test.ts
+++ b/packages/frontend/src/resolver.test.ts
@@ -64,18 +64,21 @@ describe("Module Resolver", () => {
       }
     });
 
-    it("should resolve .NET imports", () => {
+    it("should not detect bare imports as .NET without resolver with bindings", () => {
+      // Import-driven resolution: bare imports like "System.IO" are only detected as .NET
+      // if a resolver is provided and the import resolves to a package with bindings.json.
+      // Without a resolver or package, bare imports are treated as unsupported node_modules.
       const result = resolveImport(
         "System.IO",
         path.join(tempDir, "src", "index.ts"),
         sourceRoot
+        // No dotnetResolver passed
       );
 
-      expect(result.ok).to.equal(true);
-      if (result.ok) {
-        expect(result.value.isLocal).to.equal(false);
-        expect(result.value.isDotNet).to.equal(true);
-        expect(result.value.originalSpecifier).to.equal("System.IO");
+      expect(result.ok).to.equal(false);
+      if (!result.ok) {
+        expect(result.error.code).to.equal("TSN1004");
+        expect(result.error.message).to.include("Unsupported module import");
       }
     });
 

--- a/packages/frontend/src/resolver.ts
+++ b/packages/frontend/src/resolver.ts
@@ -3,10 +3,12 @@
  * Main dispatcher - re-exports from resolver/ subdirectory
  */
 
-export type { ResolvedModule } from "./resolver/index.js";
+export type { ResolvedModule, ResolvedDotNetImport } from "./resolver/index.js";
 export {
   resolveImport,
   resolveModulePath,
   getNamespaceFromPath,
   getClassNameFromPath,
+  DotNetImportResolver,
+  createDotNetImportResolver,
 } from "./resolver/index.js";

--- a/packages/frontend/src/resolver/dotnet-import-resolver.ts
+++ b/packages/frontend/src/resolver/dotnet-import-resolver.ts
@@ -1,0 +1,226 @@
+/**
+ * Import-driven .NET namespace resolution
+ *
+ * Determines if an import specifier refers to a CLR namespace by checking
+ * if bindings.json exists in the package's namespace directory.
+ *
+ * This is the ONLY mechanism for detecting .NET imports - no heuristics,
+ * no special-casing for @tsonic/dotnet or any other package.
+ */
+
+import { existsSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { createRequire } from "node:module";
+
+/**
+ * Result of resolving a .NET import
+ */
+export type ResolvedDotNetImport =
+  | {
+      readonly isDotNet: true;
+      readonly packageName: string;
+      readonly resolvedNamespace: string;
+      readonly bindingsPath: string;
+      readonly metadataPath: string | undefined;
+    }
+  | {
+      readonly isDotNet: false;
+    };
+
+/**
+ * Parsed module specifier
+ */
+type ParsedSpecifier = {
+  readonly packageName: string;
+  readonly subpath: string;
+};
+
+/**
+ * Resolver for .NET namespace imports
+ *
+ * An import is a CLR namespace import iff:
+ * - It's a package import with a subpath (e.g., @scope/pkg/Namespace)
+ * - The package contains bindings.json in that subpath directory
+ *
+ * This works for any bindings provider package, not just @tsonic/dotnet.
+ */
+export class DotNetImportResolver {
+  // Cache: packageName -> packageRoot (or null if not found)
+  private readonly pkgRootCache = new Map<string, string | null>();
+
+  // Cache: absolute bindingsPath -> exists
+  private readonly bindingsExistsCache = new Map<string, boolean>();
+
+  // require function for Node resolution from the base directory
+  private readonly require: NodeRequire;
+
+  constructor(baseDir: string) {
+    // Create a require function that resolves relative to baseDir
+    this.require = createRequire(join(baseDir, "package.json"));
+  }
+
+  /**
+   * Resolve an import specifier to determine if it's a CLR namespace import
+   */
+  resolve(moduleSpecifier: string): ResolvedDotNetImport {
+    // Skip local imports
+    if (moduleSpecifier.startsWith(".") || moduleSpecifier.startsWith("/")) {
+      return { isDotNet: false };
+    }
+
+    // Parse the specifier into package name and subpath
+    const parsed = this.parseModuleSpecifier(moduleSpecifier);
+    if (!parsed) {
+      return { isDotNet: false };
+    }
+
+    const { packageName, subpath } = parsed;
+
+    // No subpath means it's not a namespace import (e.g., just "@tsonic/dotnet")
+    if (!subpath) {
+      return { isDotNet: false };
+    }
+
+    // Resolve package root using Node resolution
+    const pkgRoot = this.resolvePkgRoot(packageName);
+    if (!pkgRoot) {
+      return { isDotNet: false };
+    }
+
+    // Check if bindings.json exists in the namespace directory
+    const bindingsPath = join(pkgRoot, subpath, "bindings.json");
+    if (!this.hasBindings(bindingsPath)) {
+      return { isDotNet: false };
+    }
+
+    // Check for optional metadata.json
+    const metadataPath = join(pkgRoot, subpath, "internal", "metadata.json");
+    const hasMetadata = this.fileExists(metadataPath);
+
+    return {
+      isDotNet: true,
+      packageName,
+      resolvedNamespace: subpath,
+      bindingsPath,
+      metadataPath: hasMetadata ? metadataPath : undefined,
+    };
+  }
+
+  /**
+   * Parse a module specifier into package name and subpath
+   *
+   * Examples:
+   * - "@tsonic/dotnet/System.IO" -> { packageName: "@tsonic/dotnet", subpath: "System.IO" }
+   * - "lodash/fp" -> { packageName: "lodash", subpath: "fp" }
+   * - "@tsonic/dotnet" -> null (no subpath)
+   * - "lodash" -> null (no subpath)
+   */
+  private parseModuleSpecifier(spec: string): ParsedSpecifier | null {
+    if (spec.startsWith("@")) {
+      // Scoped package: @scope/pkg/subpath
+      const match = spec.match(/^(@[^/]+\/[^/]+)(?:\/(.+))?$/);
+      if (!match) return null;
+      const packageName = match[1];
+      const subpath = match[2];
+      if (!packageName || !subpath) return null;
+      return { packageName, subpath };
+    } else {
+      // Regular package: pkg/subpath
+      const slashIdx = spec.indexOf("/");
+      if (slashIdx === -1) return null;
+      return {
+        packageName: spec.slice(0, slashIdx),
+        subpath: spec.slice(slashIdx + 1),
+      };
+    }
+  }
+
+  /**
+   * Resolve package root directory using Node resolution
+   *
+   * Uses require.resolve to find the package's package.json,
+   * then returns the directory containing it.
+   */
+  private resolvePkgRoot(packageName: string): string | null {
+    const cached = this.pkgRootCache.get(packageName);
+    if (cached !== undefined) {
+      return cached;
+    }
+
+    try {
+      // Try to resolve the package's package.json directly
+      const pkgJsonPath = this.require.resolve(`${packageName}/package.json`);
+      const pkgRoot = dirname(pkgJsonPath);
+      this.pkgRootCache.set(packageName, pkgRoot);
+      return pkgRoot;
+    } catch {
+      // package.json might not be exported - try finding package root via node_modules path
+      // This works by looking for node_modules/<package-name> in the require paths
+      try {
+        const paths = this.require.resolve.paths(packageName);
+        if (paths) {
+          for (const searchPath of paths) {
+            // For scoped packages, the path structure is node_modules/@scope/name
+            const pkgDir = packageName.startsWith("@")
+              ? join(searchPath, packageName)
+              : join(searchPath, packageName);
+
+            // Check if package.json exists at this location
+            if (existsSync(join(pkgDir, "package.json"))) {
+              this.pkgRootCache.set(packageName, pkgDir);
+              return pkgDir;
+            }
+          }
+        }
+      } catch {
+        // Fallback failed
+      }
+
+      this.pkgRootCache.set(packageName, null);
+      return null;
+    }
+  }
+
+  /**
+   * Check if bindings.json exists at the given path (cached)
+   */
+  private hasBindings(bindingsPath: string): boolean {
+    const cached = this.bindingsExistsCache.get(bindingsPath);
+    if (cached !== undefined) {
+      return cached;
+    }
+
+    const exists = existsSync(bindingsPath);
+    this.bindingsExistsCache.set(bindingsPath, exists);
+    return exists;
+  }
+
+  /**
+   * Check if a file exists (not cached - used for optional files)
+   */
+  private fileExists(filePath: string): boolean {
+    return existsSync(filePath);
+  }
+
+  /**
+   * Get all discovered binding paths (for loading)
+   */
+  getDiscoveredBindingPaths(): ReadonlySet<string> {
+    const paths = new Set<string>();
+    for (const [path, exists] of this.bindingsExistsCache) {
+      if (exists) {
+        paths.add(path);
+      }
+    }
+    return paths;
+  }
+}
+
+/**
+ * Create a resolver instance for a given source root
+ */
+export const createDotNetImportResolver = (
+  sourceRoot: string
+): DotNetImportResolver => {
+  return new DotNetImportResolver(sourceRoot);
+};

--- a/packages/frontend/src/resolver/index.ts
+++ b/packages/frontend/src/resolver/index.ts
@@ -11,3 +11,8 @@ export {
 export { resolveModulePath } from "./path-resolution.js";
 export { getNamespaceFromPath } from "./namespace.js";
 export { getClassNameFromPath } from "./naming.js";
+export {
+  DotNetImportResolver,
+  createDotNetImportResolver,
+  type ResolvedDotNetImport,
+} from "./dotnet-import-resolver.js";

--- a/packages/frontend/src/resolver/types.ts
+++ b/packages/frontend/src/resolver/types.ts
@@ -7,6 +7,8 @@ export type ResolvedModule = {
   readonly isLocal: boolean;
   readonly isDotNet: boolean;
   readonly originalSpecifier: string;
+  // For .NET imports: the CLR namespace (e.g., "System" from "@tsonic/dotnet/System")
+  readonly resolvedNamespace?: string;
   // For module bindings (Node.js APIs mapped to CLR types)
   readonly resolvedClrType?: string; // e.g., "Tsonic.NodeApi.fs"
   readonly resolvedAssembly?: string; // e.g., "Tsonic.NodeApi"

--- a/packages/frontend/src/types/module.ts
+++ b/packages/frontend/src/types/module.ts
@@ -97,8 +97,3 @@ export const addModule = (
 
 export const isLocalImport = (importSpec: string): boolean =>
   importSpec.startsWith(".") || importSpec.startsWith("/");
-
-export const isDotNetImport = (importSpec: string): boolean =>
-  !isLocalImport(importSpec) &&
-  !importSpec.includes("/") &&
-  /^[A-Z]/.test(importSpec);

--- a/packages/frontend/src/validation/imports.ts
+++ b/packages/frontend/src/validation/imports.ts
@@ -70,7 +70,8 @@ export const validateImportDeclaration = (
   const result = resolveImport(
     importPath,
     sourceFile.fileName,
-    program.options.sourceRoot
+    program.options.sourceRoot,
+    program.dotnetResolver
   );
 
   if (!result.ok) {

--- a/packages/frontend/src/validator.test.ts
+++ b/packages/frontend/src/validator.test.ts
@@ -15,6 +15,7 @@ import { TsonicProgram } from "./program.js";
 import { validateProgram } from "./validator.js";
 import { DotnetMetadataRegistry } from "./dotnet-metadata.js";
 import { BindingRegistry } from "./program/bindings.js";
+import { createDotNetImportResolver } from "./resolver/dotnet-import-resolver.js";
 
 /**
  * Helper to create a test program from source code
@@ -70,6 +71,7 @@ const createTestProgram = (
     sourceFiles: [sourceFile],
     metadata: new DotnetMetadataRegistry(),
     bindings: new BindingRegistry(),
+    dotnetResolver: createDotNetImportResolver("/test"),
   };
 };
 


### PR DESCRIPTION
Replace heuristic-based .NET import detection with import-driven resolution that checks for bindings.json in npm packages. This enables proper detection of .NET imports from any bindings provider package (not just @tsonic/dotnet).

Changes:
- Add DotNetImportResolver class for resolving npm-style .NET imports
- Update extractImports to use resolver for isDotNet detection
- Add resolvedNamespace to IrImport for proper using statement generation
- Remove old isDotNetImport() heuristic from module.ts
- Update TsonicProgram type to include dotnetResolver
- Fix verbose-only console.log in creation.ts
- Remove debug console.logs from test files

The resolver detects .NET imports by:
1. Parsing npm package specifiers (e.g., @tsonic/dotnet/System.IO)
2. Resolving package root via Node's require.resolve
3. Checking for bindings.json in the namespace subdirectory

🤖 Generated with [Claude Code](https://claude.com/claude-code)