### PR TITLE
fix: Emit static container when interface has same name as file

### DIFF
--- a/packages/emitter/src/core/module-emitter/orchestrator.ts
+++ b/packages/emitter/src/core/module-emitter/orchestrator.ts
@@ -69,16 +69,22 @@ export const emitModule = (
     hasInheritance
   );
 
-  // Emit static container class unless there's a namespace-level class with same name
+  // Emit static container class if there are any static members
+  // Use __Module suffix when there's a name collision with namespace-level declarations
   let staticContainerCode = "";
   let finalContext = namespaceResult.context;
 
-  if (!hasMatchingClassName(namespaceLevelDecls, module.className)) {
+  if (staticContainerMembers.length > 0) {
+    const hasCollision = hasMatchingClassName(
+      namespaceLevelDecls,
+      module.className
+    );
     const containerResult = emitStaticContainer(
       module,
       staticContainerMembers,
       namespaceResult.context, // Use context from namespace declarations to preserve usings
-      hasInheritance
+      hasInheritance,
+      hasCollision // Add __Module suffix only when there's a name collision
     );
     staticContainerCode = containerResult.code;
     finalContext = containerResult.context;

--- a/packages/emitter/src/core/module-emitter/static-container.ts
+++ b/packages/emitter/src/core/module-emitter/static-container.ts
@@ -30,12 +30,14 @@ export const hasMatchingClassName = (
 
 /**
  * Emit static container class for module-level members
+ * @param useModuleSuffix - If true, adds __Module suffix to avoid collision with namespace-level types
  */
 export const emitStaticContainer = (
   module: IrModule,
   members: readonly IrStatement[],
   baseContext: EmitterContext,
-  hasInheritance: boolean
+  hasInheritance: boolean,
+  useModuleSuffix: boolean = false
 ): StaticContainerResult => {
   const classContext = withStatic(indent(baseContext), true);
   const bodyContext = indent(classContext);
@@ -43,7 +45,11 @@ export const emitStaticContainer = (
 
   const containerParts: string[] = [];
   const escapedClassName = escapeCSharpIdentifier(module.className);
-  containerParts.push(`${ind}public static class ${escapedClassName}`);
+  // Use __Module suffix when there's a collision with namespace-level type declarations
+  const containerName = useModuleSuffix
+    ? `${escapedClassName}__Module`
+    : escapedClassName;
+  containerParts.push(`${ind}public static class ${containerName}`);
   containerParts.push(`${ind}{`);
 
   const bodyParts: string[] = [];

--- a/packages/emitter/src/core/module-map.ts
+++ b/packages/emitter/src/core/module-map.ts
@@ -102,10 +102,21 @@ export const buildModuleMap = (
   // Build the map
   for (const module of modules) {
     const canonicalPath = canonicalizeFilePath(module.filePath);
+
+    // Check if module has a type declaration (class/interface) with same name as className
+    // This determines whether value imports need to use __Module suffix
+    const hasTypeCollision = module.body.some(
+      (stmt) =>
+        (stmt.kind === "classDeclaration" ||
+          stmt.kind === "interfaceDeclaration") &&
+        stmt.name === module.className
+    );
+
     map.set(canonicalPath, {
       namespace: module.namespace,
       className: module.className,
       filePath: canonicalPath,
+      hasTypeCollision,
     });
   }
 

--- a/packages/emitter/src/emitter-types/core.ts
+++ b/packages/emitter/src/emitter-types/core.ts
@@ -12,6 +12,11 @@ export type ModuleIdentity = {
   readonly namespace: string;
   readonly className: string;
   readonly filePath: string;
+  /**
+   * True if the module has a type declaration (class/interface) with the same name as className.
+   * When true, value imports should target ClassName__Module instead of ClassName.
+   */
+  readonly hasTypeCollision: boolean;
 };
 
 /**

--- a/test/fixtures/interface-with-functions/expected/dotnet.txt
+++ b/test/fixtures/interface-with-functions/expected/dotnet.txt
@@ -1,0 +1,1 @@
+Alice <alice@example.com>

--- a/test/fixtures/interface-with-functions/package-lock.json
+++ b/test/fixtures/interface-with-functions/package-lock.json
@@ -1,0 +1,37 @@
+{
+  "name": "tsonic-e2e-test",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "tsonic-e2e-test",
+      "version": "1.0.0",
+      "dependencies": {
+        "@tsonic/dotnet": "^0.5.1",
+        "@tsonic/dotnet-globals": "^0.1.2"
+      }
+    },
+    "node_modules/@tsonic/dotnet": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@tsonic/dotnet/-/dotnet-0.5.2.tgz",
+      "integrity": "sha512-wY6wODhPJdGXOmGLcJ02v7FYCrW2mpUBQ4KATaxWf7v36GlzjNIghT+F2+3/FJTn0nobQ/W1UTZNJ2NzXmE5vA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tsonic/types": "^0.2.0"
+      }
+    },
+    "node_modules/@tsonic/dotnet-globals": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@tsonic/dotnet-globals/-/dotnet-globals-0.1.2.tgz",
+      "integrity": "sha512-VJZr5ljccTmhCewr0nwEkZxLiPzZw0Tv2521X7JTbuqU4/H31ZJCaW8YnUnFul71+BcMHu1pXzGhRCt/jMgWSQ==",
+      "license": "MIT"
+    },
+    "node_modules/@tsonic/types": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@tsonic/types/-/types-0.2.0.tgz",
+      "integrity": "sha512-g0gAEG+wz/bL3PS45uIIRKEtOHn4UsCaqiWe3o0QUeqptYQ2j9NJK5wb4YJtHNVWqUsw5xkF02jJXO5Srqn7NQ==",
+      "license": "MIT"
+    }
+  }
+}

--- a/test/fixtures/interface-with-functions/package.json
+++ b/test/fixtures/interface-with-functions/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "tsonic-e2e-test",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "@tsonic/dotnet": "^0.5.1",
+    "@tsonic/dotnet-globals": "^0.1.2"
+  }
+}

--- a/test/fixtures/interface-with-functions/src/index.ts
+++ b/test/fixtures/interface-with-functions/src/index.ts
@@ -1,0 +1,12 @@
+/**
+ * Entry point - tests importing interface + functions from same module
+ * where filename matches interface name (causes __Module suffix)
+ */
+
+import { Console } from "@tsonic/dotnet/System";
+import { User, createUser, formatUser } from "./models/User.ts";
+
+export function main(): void {
+  const user: User = createUser(1, "Alice", "alice@example.com");
+  Console.WriteLine(formatUser(user));
+}

--- a/test/fixtures/interface-with-functions/src/models/User.ts
+++ b/test/fixtures/interface-with-functions/src/models/User.ts
@@ -1,0 +1,18 @@
+/**
+ * User model - interface + factory functions with same name as file
+ * Tests the __Module suffix when there's a name collision
+ */
+
+export interface User {
+  id: number;
+  name: string;
+  email: string;
+}
+
+export function createUser(id: number, name: string, email: string): User {
+  return { id, name, email };
+}
+
+export function formatUser(user: User): string {
+  return `${user.name} <${user.email}>`;
+}

--- a/test/fixtures/interface-with-functions/tsonic.dotnet.json
+++ b/test/fixtures/interface-with-functions/tsonic.dotnet.json
@@ -1,0 +1,6 @@
+{
+  "entry": "src/index.ts",
+  "rootNamespace": "InterfaceWithFunctions",
+  "outputName": "interface-with-functions",
+  "runtime": "dotnet"
+}


### PR DESCRIPTION
When a TypeScript file exports both an interface AND functions where the interface name matches the filename (e.g., User.ts exports interface User + createUser() + formatUser()), the functions were silently dropped.

Root cause: orchestrator.ts skipped the static container entirely when there was a name collision, instead of renaming it.

Solution:
- Always emit static container when there are static members
- Use __Module suffix (e.g., User__Module) when collision exists
- Update import bindings to route to __Module class when needed
- Add hasTypeCollision flag to ModuleIdentity for tracking

Also adds E2E test for interface+functions collision scenario.

🤖 Generated with [Claude Code](https://claude.com/claude-code)