### PR TITLE
chore: Bump versions for 0.0.7 release

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tsonic/cli",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Command-line interface for Tsonic compiler",
   "type": "module",
   "main": "./dist/index.js",
@@ -26,8 +26,8 @@
   },
   "dependencies": {
     "@tsonic/backend": "0.0.4",
-    "@tsonic/emitter": "0.0.4",
-    "@tsonic/frontend": "0.0.3"
+    "@tsonic/emitter": "0.0.5",
+    "@tsonic/frontend": "0.0.4"
   },
   "devDependencies": {
     "@types/chai": "5.2.2",

--- a/packages/emitter/package.json
+++ b/packages/emitter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tsonic/emitter",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "C# code generator for Tsonic compiler",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tsonic/frontend",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "TypeScript parser and IR builder for Tsonic compiler",
   "type": "module",
   "main": "./dist/index.js",

--- a/test/fixtures/generic-null-default/src/index.ts
+++ b/test/fixtures/generic-null-default/src/index.ts
@@ -34,7 +34,9 @@ export function main(): void {
 
   // Test concrete - both are null
   const concrete = getConcreteNull();
-  Console.WriteLine(`Both null: ${concrete.value === null && concrete.error === null}`);
+  Console.WriteLine(
+    `Both null: ${concrete.value === null && concrete.error === null}`
+  );
 
   Console.WriteLine("All tests passed!");
 }


### PR DESCRIPTION
- @tsonic/frontend: 0.0.3 → 0.0.4
- @tsonic/emitter: 0.0.4 → 0.0.5
- @tsonic/cli: 0.0.6 → 0.0.7

🤖 Generated with [Claude Code](https://claude.com/claude-code)