### PR TITLE
test(golden): harden expectDiagnostics infrastructure

### DIFF
--- a/packages/emitter/src/golden-tests/config-parser.ts
+++ b/packages/emitter/src/golden-tests/config-parser.ts
@@ -3,7 +3,75 @@
  */
 
 import YAML from "yaml";
-import { TestEntry } from "./types.js";
+import { DiagnosticsMode, TestEntry } from "./types.js";
+
+/**
+ * Normalize and deduplicate diagnostic codes.
+ * - Trims whitespace
+ * - Filters empty strings
+ * - Removes duplicates
+ * - Sorts for deterministic ordering
+ */
+const normalizeDiagnosticCodes = (
+  codes: readonly string[]
+): readonly string[] => {
+  const normalized = codes.map((c) => c.trim()).filter((c) => c.length > 0);
+  return [...new Set(normalized)].sort();
+};
+
+/**
+ * Parse and validate expectDiagnostics field.
+ * - Must be an array of strings
+ * - Each code must match TSN#### format
+ * - Returns undefined if empty or not present
+ */
+const parseExpectDiagnostics = (
+  value: unknown
+): readonly string[] | undefined => {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+
+  if (!Array.isArray(value)) {
+    throw new Error("expectDiagnostics must be an array of strings");
+  }
+
+  for (const v of value) {
+    if (typeof v !== "string") {
+      throw new Error(
+        `expectDiagnostics must contain strings. Got: ${JSON.stringify(v)}`
+      );
+    }
+  }
+
+  const codes = normalizeDiagnosticCodes(value);
+
+  // Enforce TSN#### format
+  for (const c of codes) {
+    if (!/^TSN\d{4}$/.test(c)) {
+      throw new Error(
+        `Invalid diagnostic code "${c}". Expected format TSN####.`
+      );
+    }
+  }
+
+  return codes.length > 0 ? codes : undefined;
+};
+
+/**
+ * Validate and parse diagnostics mode.
+ */
+const parseDiagnosticsMode = (value: unknown): DiagnosticsMode | undefined => {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+  if (value === "contains" || value === "exact") {
+    return value;
+  }
+  throw new Error(
+    `Invalid expectDiagnosticsMode: "${value}". Must be "contains" or "exact".`
+  );
+};
 
 /**
  * Parse config.yaml and extract test entries
@@ -32,36 +100,67 @@ export const parseConfigYaml = (yamlContent: string): readonly TestEntry[] => {
         }
 
         entries.push({ input, title });
-      } else if (item.input && item.title) {
-        // Explicit format: { input: "File.ts", title: "...", expectDiagnostics?: [...] }
-        const input = item.input;
-        const title = item.title;
+      } else if ("input" in item && "title" in item) {
+        // Explicit format: { input: "File.ts", title: "...", expectDiagnostics?: [...], expectDiagnosticsMode?: "..." }
+        const input = (item as Record<string, unknown>).input;
+        const title = (item as Record<string, unknown>).title;
 
         if (typeof input !== "string" || typeof title !== "string") {
           throw new Error(
-            "Each test entry must have 'input' and 'title' fields"
+            "Each test entry must have 'input' and 'title' as strings"
           );
         }
 
-        const expectDiagnostics = Array.isArray(item.expectDiagnostics)
-          ? item.expectDiagnostics.map(String)
-          : undefined;
+        if (!input.endsWith(".ts")) {
+          throw new Error(`input must end with .ts: ${input}`);
+        }
 
-        entries.push({ input, title, expectDiagnostics });
+        const expectDiagnostics = parseExpectDiagnostics(
+          (item as Record<string, unknown>).expectDiagnostics
+        );
+
+        const expectDiagnosticsMode = parseDiagnosticsMode(
+          (item as Record<string, unknown>).expectDiagnosticsMode
+        );
+
+        // Validate that mode is only set when diagnostics are expected
+        if (expectDiagnosticsMode && !expectDiagnostics) {
+          throw new Error(
+            `expectDiagnosticsMode is set for ${input} but expectDiagnostics is missing.`
+          );
+        }
+
+        entries.push({
+          input,
+          title,
+          expectDiagnostics,
+          expectDiagnosticsMode,
+        });
       } else {
         throw new Error(`Invalid test entry: ${JSON.stringify(item)}`);
       }
     } else if (typeof item === "string") {
       // Quoted string format: "File.ts: title here"
-      const match = item.match(/^(\S+\.ts):\s*(.+)$/);
-      if (!match || !match[1] || !match[2]) {
-        throw new Error(`Invalid test entry format: ${item}`);
+      // Split on first colon to allow paths with spaces
+      const colonIdx = item.indexOf(":");
+      if (colonIdx === -1) {
+        throw new Error(
+          `Invalid test entry format: "${item}". Expected "File.ts: title".`
+        );
       }
 
-      entries.push({
-        input: match[1],
-        title: match[2].trim(),
-      });
+      const input = item.slice(0, colonIdx).trim();
+      const title = item.slice(colonIdx + 1).trim();
+
+      if (!input.endsWith(".ts")) {
+        throw new Error(`input must end with .ts: ${input}`);
+      }
+
+      if (title.length === 0) {
+        throw new Error(`Title cannot be empty for ${input}`);
+      }
+
+      entries.push({ input, title });
     } else {
       throw new Error(`Invalid test entry: ${JSON.stringify(item)}`);
     }

--- a/packages/emitter/src/golden-tests/discovery.ts
+++ b/packages/emitter/src/golden-tests/discovery.ts
@@ -27,20 +27,31 @@ export const discoverScenarios = (baseDir: string): readonly Scenario[] => {
 
       // Create scenarios for each test entry
       for (const entry of testEntries) {
+        // Defensive check: parser should enforce this, but double-check
+        if (!entry.input.endsWith(".ts")) {
+          throw new Error(
+            `Invalid input (must end with .ts): ${entry.input} (config: ${configPath})`
+          );
+        }
+
         const inputPath = path.join(dir, entry.input);
         const baseName = path.basename(entry.input, ".ts");
         const expectedPath = path.join(dir, `${baseName}.cs`);
 
         // Verify input file exists
         if (!fs.existsSync(inputPath)) {
-          throw new Error(`Input file not found: ${inputPath}`);
+          throw new Error(
+            `Input file not found: ${inputPath} (title: "${entry.title}", config: ${configPath})`
+          );
         }
 
         // Only require .cs file if not expecting diagnostics
         const expectDiagnostics = entry.expectDiagnostics;
         if (!expectDiagnostics?.length) {
           if (!fs.existsSync(expectedPath)) {
-            throw new Error(`Expected file not found: ${expectedPath}`);
+            throw new Error(
+              `Expected file not found: ${expectedPath} (title: "${entry.title}", config: ${configPath})`
+            );
           }
         }
 
@@ -50,6 +61,7 @@ export const discoverScenarios = (baseDir: string): readonly Scenario[] => {
           inputPath,
           expectedPath: expectDiagnostics?.length ? undefined : expectedPath,
           expectDiagnostics,
+          expectDiagnosticsMode: entry.expectDiagnosticsMode,
         });
       }
     }

--- a/packages/emitter/src/golden-tests/types.ts
+++ b/packages/emitter/src/golden-tests/types.ts
@@ -2,10 +2,18 @@
  * Golden test types
  */
 
+/**
+ * Diagnostics matching mode:
+ * - "contains": expected codes must be present, extra codes allowed (default)
+ * - "exact": actual codes must exactly match expected codes
+ */
+export type DiagnosticsMode = "contains" | "exact";
+
 export type TestEntry = {
   readonly input: string;
   readonly title: string;
   readonly expectDiagnostics?: readonly string[];
+  readonly expectDiagnosticsMode?: DiagnosticsMode;
 };
 
 export type Scenario = {
@@ -14,6 +22,7 @@ export type Scenario = {
   readonly inputPath: string;
   readonly expectedPath?: string; // Optional when expectDiagnostics is set
   readonly expectDiagnostics?: readonly string[];
+  readonly expectDiagnosticsMode?: DiagnosticsMode;
 };
 
 export type DescribeNode = {

--- a/packages/emitter/testcases/types/tuples-intersections/config.yaml
+++ b/packages/emitter/testcases/types/tuples-intersections/config.yaml
@@ -1,3 +1,4 @@
 - input: TuplesAndIntersections.ts
-  title: mixed variadic tuples are rejected with TSN7408
-  expectDiagnostics: [TSN7408]
+  title: mixed variadic tuples and intersection types are rejected
+  expectDiagnostics: [TSN7408, TSN7410]
+  expectDiagnosticsMode: exact


### PR DESCRIPTION
- Parser validation: require strings, enforce TSN#### format
- Add diagnostics mode (contains/exact) for strict matching
- Parser: use "in" checks, split-on-first-colon, validate .ts extension
- Discovery: skip .cs check when expectDiagnostics set, defensive checks
- Runner: clearer mismatch errors with mode/title/config context
- Add tuples-intersections test with exact mode as example

🤖 Generated with [Claude Code](https://claude.com/claude-code)