### PR TITLE
feat(validator): add TSN7410 intersection types + utility type valida…

### DIFF
--- a/packages/frontend/src/types/diagnostic.ts
+++ b/packages/frontend/src/types/diagnostic.ts
@@ -40,6 +40,7 @@ export type DiagnosticCode =
   | "TSN7407" // Conditional types not supported
   | "TSN7408" // Tuple types not supported
   | "TSN7409" // 'infer' keyword not supported
+  | "TSN7410" // Intersection types not supported
   | "TSN7413" // Dictionary key must be string type
   // Metadata loading errors (TSN9001-TSN9018)
   | "TSN9001" // Metadata file not found

--- a/packages/frontend/src/validation/unsupported-utility-types.ts
+++ b/packages/frontend/src/validation/unsupported-utility-types.ts
@@ -1,0 +1,54 @@
+/**
+ * Centralized list of unsupported TypeScript utility types
+ *
+ * These utility types internally use mapped or conditional types which are not
+ * supported in Tsonic. They are detected by name in TypeReferenceNode validation.
+ *
+ * Note: This only applies to the built-in utility types from TypeScript's lib.
+ * User-defined types with these names (without type arguments) are allowed.
+ */
+
+/**
+ * Mapped-type utility types (TSN7406)
+ *
+ * These expand to mapped types internally:
+ * - Partial<T>   → { [P in keyof T]?: T[P] }
+ * - Required<T>  → { [P in keyof T]-?: T[P] }
+ * - Readonly<T>  → { readonly [P in keyof T]: T[P] }
+ * - Pick<T, K>   → { [P in K]: T[P] }
+ * - Omit<T, K>   → { [P in Exclude<keyof T, K>]: T[P] }
+ *
+ * Note: Record<K, V> is handled separately (allowed when K is string, TSN7413 otherwise)
+ * Note: ReadonlyArray<T> is NOT a mapped type - it maps to IReadOnlyList<T> and is supported
+ */
+export const UNSUPPORTED_MAPPED_UTILITY_TYPES = new Set([
+  "Partial",
+  "Required",
+  "Readonly",
+  "Pick",
+  "Omit",
+]);
+
+/**
+ * Conditional-type utility types (TSN7407)
+ *
+ * These expand to conditional types internally:
+ * - Extract<T, U>         → T extends U ? T : never
+ * - Exclude<T, U>         → T extends U ? never : T
+ * - NonNullable<T>        → T & {}  (or T extends null | undefined ? never : T)
+ * - ReturnType<T>         → T extends (...args: any) => infer R ? R : any
+ * - Parameters<T>         → T extends (...args: infer P) => any ? P : never
+ * - ConstructorParameters → ConstructorType extends abstract new (...args: infer P) => any ? P : never
+ * - InstanceType<T>       → T extends abstract new (...args: any) => infer R ? R : any
+ * - Awaited<T>            → T extends PromiseLike<infer U> ? Awaited<U> : T
+ */
+export const UNSUPPORTED_CONDITIONAL_UTILITY_TYPES = new Set([
+  "Extract",
+  "Exclude",
+  "NonNullable",
+  "ReturnType",
+  "Parameters",
+  "ConstructorParameters",
+  "InstanceType",
+  "Awaited",
+]);


### PR DESCRIPTION
…tion

- TSN7410: reject intersection types (A & B) with clear error message
- TSN7406: reject mapped utility types (Partial, Required, Readonly, Pick, Omit)
- TSN7407: reject conditional utility types (Extract, Exclude, NonNullable, etc.)
- Add hasTypeArgs check to prevent false positives for user-defined types
- Centralize utility type lists in unsupported-utility-types.ts
- Add comprehensive unit tests for all validation rules

🤖 Generated with [Claude Code](https://claude.com/claude-code)