### PR TITLE
feat: add union narrowing via type predicate functions

### DIFF
--- a/packages/emitter/src/emitter-types/core.ts
+++ b/packages/emitter/src/emitter-types/core.ts
@@ -154,6 +154,13 @@ export type EmitterContext = {
   readonly returnType?: IrType;
   /** Map of local type names to their definitions (for property type lookup) */
   readonly localTypes?: ReadonlyMap<string, LocalTypeInfo>;
+  /** Scoped identifier remaps for union narrowing (e.g., account -> account__1_3) */
+  readonly narrowedBindings?: ReadonlyMap<
+    string,
+    { readonly name: string; readonly type?: IrType }
+  >;
+  /** Counter for generating unique temp variable names */
+  readonly tempVarId?: number;
 };
 
 /**

--- a/packages/emitter/src/expressions/identifiers.ts
+++ b/packages/emitter/src/expressions/identifiers.ts
@@ -34,6 +34,14 @@ export const emitIdentifier = (
     return [{ text: "default" }, context];
   }
 
+  // Narrowing remap (e.g., account -> account__1_3 inside type guard then-branch)
+  if (context.narrowedBindings) {
+    const narrowed = context.narrowedBindings.get(expr.name);
+    if (narrowed) {
+      return [{ text: escapeCSharpIdentifier(narrowed.name) }, context];
+    }
+  }
+
   // Check if this identifier is from an import
   if (context.importBindings) {
     const binding = context.importBindings.get(expr.name);

--- a/packages/emitter/testcases/functions/type-guards/TypeGuards.cs
+++ b/packages/emitter/testcases/functions/type-guards/TypeGuards.cs
@@ -38,15 +38,17 @@ namespace TestCases.functions.typeguards
 
                 public static void makeSound(Animal animal)
                     {
-                    if (isDog(animal))
-                        {
-                        animal.bark();
-                        }
+                    if (animal.Is1())
+                    {
+                        var animal__1_1 = animal.As1();
+                        animal__1_1.bark();
+                    }
                     else
-                        if (isCat(animal))
-                            {
-                            animal.meow();
-                            }
+                        if (animal.Is2())
+                        {
+                            var animal__2_2 = animal.As2();
+                            animal__2_2.meow();
+                        }
                     }
 
                 public static string processValue(global::Tsonic.Runtime.Union<string, double> value)

--- a/packages/emitter/testcases/real-world/type-guards/type-guards.cs
+++ b/packages/emitter/testcases/real-world/type-guards/type-guards.cs
@@ -50,20 +50,23 @@ namespace TestCases.realworld.typeguards
 
                 public static string getAccountDescription(Account account)
                     {
-                    if (isUser(account))
-                        {
-                        return $"User: {account.username} ({account.email})";
-                        }
+                    if (account.Is1())
+                    {
+                        var account__1_1 = account.As1();
+                        return $"User: {account__1_1.username} ({account__1_1.email})";
+                    }
                     else
-                        if (isAdmin(account))
-                            {
-                            return $"Admin: {account.username} with {(global::Tsonic.JSRuntime.Array.length(account.permissions))} permissions";
-                            }
+                        if (account.Is2())
+                        {
+                            var account__2_2 = account.As2();
+                            return $"Admin: {account__2_2.username} with {(global::Tsonic.JSRuntime.Array.length(account__2_2.permissions))} permissions";
+                        }
                         else
-                            if (isGuest(account))
-                                {
-                                return $"Guest session: {account.sessionId}";
-                                }
+                            if (account.Is3())
+                            {
+                                var account__3_3 = account.As3();
+                                return $"Guest session: {account__3_3.sessionId}";
+                            }
                     return "Unknown account type";
                     }
 
@@ -74,10 +77,11 @@ namespace TestCases.realworld.typeguards
 
                 public static global::System.Collections.Generic.List<string> getPermissions(Account account)
                     {
-                    if (isAdmin(account))
-                        {
-                        return account.permissions;
-                        }
+                    if (account.Is2())
+                    {
+                        var account__2_1 = account.As2();
+                        return account__2_1.permissions;
+                    }
                     return new global::System.Collections.Generic.List<string>();
                     }
 

--- a/packages/frontend/src/ir/converters/expressions/calls.ts
+++ b/packages/frontend/src/ir/converters/expressions/calls.ts
@@ -10,6 +10,8 @@ import {
   checkIfRequiresSpecialization,
 } from "./helpers.js";
 import { convertExpression } from "../../expression-converter.js";
+import { convertType, convertTsTypeToIr } from "../../type-converter.js";
+import { IrType } from "../../types.js";
 
 /**
  * Extract argument passing modes from resolved signature
@@ -75,6 +77,63 @@ const extractArgumentPassing = (
 };
 
 /**
+ * Safely convert a ts.Type to IrType
+ */
+const convertTsTypeToIrSafe = (
+  tsType: ts.Type,
+  node: ts.Node,
+  checker: ts.TypeChecker
+): IrType | undefined => {
+  try {
+    const typeNode = checker.typeToTypeNode(
+      tsType,
+      node,
+      ts.NodeBuilderFlags.None
+    );
+    return typeNode
+      ? convertType(typeNode, checker)
+      : convertTsTypeToIr(tsType, checker);
+  } catch {
+    return undefined;
+  }
+};
+
+/**
+ * Extract type predicate narrowing metadata from a call expression.
+ * Returns narrowing info if the callee is a type predicate function (x is T).
+ */
+const extractNarrowing = (
+  node: ts.CallExpression,
+  checker: ts.TypeChecker
+): IrCallExpression["narrowing"] => {
+  try {
+    const sig = checker.getResolvedSignature(node);
+    if (!sig) return undefined;
+
+    const pred = checker.getTypePredicateOfSignature(sig);
+    // We only handle "param is T" predicates (not "this is T")
+    if (
+      pred &&
+      pred.kind === ts.TypePredicateKind.Identifier &&
+      pred.parameterIndex !== undefined &&
+      pred.type
+    ) {
+      const targetType = convertTsTypeToIrSafe(pred.type, node, checker);
+      if (targetType) {
+        return {
+          kind: "typePredicate",
+          argIndex: pred.parameterIndex,
+          targetType,
+        };
+      }
+    }
+    return undefined;
+  } catch {
+    return undefined;
+  }
+};
+
+/**
  * Convert call expression
  */
 export const convertCallExpression = (
@@ -85,6 +144,7 @@ export const convertCallExpression = (
   const typeArguments = extractTypeArguments(node, checker);
   const requiresSpecialization = checkIfRequiresSpecialization(node, checker);
   const argumentPassing = extractArgumentPassing(node, checker);
+  const narrowing = extractNarrowing(node, checker);
 
   return {
     kind: "call",
@@ -103,6 +163,7 @@ export const convertCallExpression = (
     typeArguments,
     requiresSpecialization,
     argumentPassing,
+    narrowing,
   };
 };
 

--- a/packages/frontend/src/ir/types/expressions.ts
+++ b/packages/frontend/src/ir/types/expressions.ts
@@ -125,6 +125,12 @@ export type IrCallExpression = {
   readonly typeArguments?: readonly IrType[]; // Explicit or inferred type arguments
   readonly requiresSpecialization?: boolean; // Flag for conditional/unsupported patterns
   readonly argumentPassing?: readonly ("value" | "ref" | "out" | "in")[]; // Passing mode for each argument
+  /** Type predicate narrowing metadata (for `x is T` predicates) */
+  readonly narrowing?: {
+    readonly kind: "typePredicate";
+    readonly argIndex: number; // which argument is being narrowed
+    readonly targetType: IrType; // the asserted type
+  };
 };
 
 export type IrNewExpression = {


### PR DESCRIPTION
Implements automatic union narrowing when using type predicate functions (e.g., `isUser(account): account is User`) in if-statements.

TypeScript:
```typescript
if (isUser(account)) {
  return account.username;
}
```

Compiles to C#:
```csharp
if (account.Is1())
{
    var account__1_1 = account.As1();
    return account__1_1.username;
}
```

Frontend changes:
- Add `narrowing` field to IrCallExpression with predicate metadata
- Extract type predicate info from TS checker in convertCallExpression

Emitter changes:
- Add `narrowedBindings` and `tempVarId` to EmitterContext
- Update emitIdentifier to remap narrowed identifiers in scope
- Add findUnionMemberIndex helper to match predicate target to union member
- Rewrite emitIfStatement to detect predicate guards and emit Union.IsN()/AsN() with scoped variable remapping

Limitations (MVP scope):
- Only handles plain identifier arguments (not foo.bar)
- No negated predicate support (!isX)
- No switch/ternary narrowing

🤖 Generated with [Claude Code](https://claude.com/claude-code)