### PR TITLE
feat(emitter): add narrowing v2 - negated guards and && compound guards

### DIFF
--- a/packages/emitter/testcases/functions/type-guards-v2/TypeGuardsV2.cs
+++ b/packages/emitter/testcases/functions/type-guards-v2/TypeGuardsV2.cs
@@ -1,0 +1,73 @@
+namespace TestCases.functions.typeguardsv2
+{
+    public class User
+    {
+        public string kind { get; set; }
+
+        public string username { get; set; }
+
+        public string email { get; set; }
+    }
+    public class Admin
+    {
+        public string kind { get; set; }
+
+        public double adminId { get; set; }
+
+        public global::System.Collections.Generic.List<string> permissions { get; set; }
+    }
+
+            public static class TypeGuardsV2
+            {
+                // type Account = global::Tsonic.Runtime.Union<User, Admin>
+
+                public static bool isUser(Account account)
+                    {
+                    return account.kind == "user";
+                    }
+
+                public static bool isAdmin(Account account)
+                    {
+                    return account.kind == "admin";
+                    }
+
+                public static string handleNotUser(Account account)
+                    {
+                    if (!account.Is1())
+                        {
+                        return $"Admin {account.adminId}";
+                        }
+                    else
+                    {
+                        var account__1_1 = account.As1();
+                        return $"User {account__1_1.username}";
+                    }
+                    }
+
+                public static string getUserWithValidEmail(Account account)
+                    {
+                    if (account.Is1())
+                    {
+                        var account__1_1 = account.As1();
+                        if (global::Tsonic.JSRuntime.String.length(account__1_1.email) > 0.0)
+                            {
+                            return account__1_1.email;
+                            }
+                    }
+                        return "no email";
+                    }
+
+                public static string getUsernameUppercase(Account account)
+                    {
+                    if (account.Is1())
+                    {
+                        var account__1_1 = account.As1();
+                        if (account__1_1.username != "")
+                            {
+                            return global::Tsonic.JSRuntime.String.toUpperCase(account__1_1.username);
+                            }
+                    }
+                        return "anonymous";
+                    }
+            }
+}

--- a/packages/emitter/testcases/functions/type-guards-v2/TypeGuardsV2.ts
+++ b/packages/emitter/testcases/functions/type-guards-v2/TypeGuardsV2.ts
@@ -1,0 +1,49 @@
+export interface User {
+  kind: "user";
+  username: string;
+  email: string;
+}
+
+export interface Admin {
+  kind: "admin";
+  adminId: number;
+  permissions: string[];
+}
+
+export type Account = User | Admin;
+
+// Type guard functions
+export function isUser(account: Account): account is User {
+  return account.kind === "user";
+}
+
+export function isAdmin(account: Account): account is Admin {
+  return account.kind === "admin";
+}
+
+// Case 1: Negated guard - narrow the else branch
+export function handleNotUser(account: Account): string {
+  if (!isUser(account)) {
+    // account is Admin here
+    return `Admin ${account.adminId}`;
+  } else {
+    // account is User here (narrowed)
+    return `User ${account.username}`;
+  }
+}
+
+// Case 2: && guard - compound condition with narrowing
+export function getUserWithValidEmail(account: Account): string {
+  if (isUser(account) && account.email.length > 0) {
+    return account.email;
+  }
+  return "no email";
+}
+
+// Case 3: && guard with method call
+export function getUsernameUppercase(account: Account): string {
+  if (isUser(account) && account.username !== "") {
+    return account.username.toUpperCase();
+  }
+  return "anonymous";
+}

--- a/packages/emitter/testcases/functions/type-guards-v2/config.yaml
+++ b/packages/emitter/testcases/functions/type-guards-v2/config.yaml
@@ -1,0 +1,1 @@
+- TypeGuardsV2.ts: should emit negated and && type guard narrowing

--- a/packages/emitter/testcases/real-world/advanced-generics/advanced-generics.cs
+++ b/packages/emitter/testcases/real-world/advanced-generics/advanced-generics.cs
@@ -25,11 +25,13 @@ namespace TestCases.realworld.advancedgenerics
     public class Result__0 <T, E>
     {
         public bool ok { get; set; }
+
         public T value { get; set; }
     }
     public class Result__1 <T, E>
     {
         public bool ok { get; set; }
+
         public E error { get; set; }
     }
     public class TreeNode<T>


### PR DESCRIPTION
Extends the union narrowing system with two new patterns:

1. Negated guard narrowing (!isX(x)):
   - `if (!isUser(account)) { A } else { B }` now narrows account in the else branch to User via account.As1()

2. Compound && guard narrowing:
   - `if (isUser(account) && account.email.length > 0)` lowers to nested if-statements preserving short-circuit semantics
   - Outer: if (account.Is1()) with var narrowed = account.As1()
   - Inner: if (narrowedCondition) with narrowed bindings in scope

Implementation:
- Extract reusable tryResolvePredicateGuard helper from v1 logic
- Add emitForcedBlockWithPreamble for injecting cast preambles
- Refactor emitIfStatement to handle 3 cases: A) Simple predicate guard (existing v1) B) Negated predicate guard (new) C) Logical && with predicate on left (new)

Adds golden tests for negated and && guard patterns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)