### PR TITLE
feat(emitter): add ternary expression narrowing for type predicates

### DIFF
--- a/packages/emitter/src/emitter-types/core.ts
+++ b/packages/emitter/src/emitter-types/core.ts
@@ -121,6 +121,19 @@ export type LocalTypeInfo =
     };
 
 /**
+ * Narrowed binding for union type narrowing.
+ * - "rename": Used in if-statements where we can declare a temp var (e.g., account -> account__1_1)
+ * - "expr": Used in ternary expressions where we inline the AsN() call (e.g., account -> (account.As1()))
+ */
+export type NarrowedBinding =
+  | { readonly kind: "rename"; readonly name: string; readonly type?: IrType }
+  | {
+      readonly kind: "expr";
+      readonly exprText: string;
+      readonly type?: IrType;
+    };
+
+/**
  * Context passed through emission process
  */
 export type EmitterContext = {
@@ -154,11 +167,8 @@ export type EmitterContext = {
   readonly returnType?: IrType;
   /** Map of local type names to their definitions (for property type lookup) */
   readonly localTypes?: ReadonlyMap<string, LocalTypeInfo>;
-  /** Scoped identifier remaps for union narrowing (e.g., account -> account__1_3) */
-  readonly narrowedBindings?: ReadonlyMap<
-    string,
-    { readonly name: string; readonly type?: IrType }
-  >;
+  /** Scoped identifier remaps for union narrowing */
+  readonly narrowedBindings?: ReadonlyMap<string, NarrowedBinding>;
   /** Counter for generating unique temp variable names */
   readonly tempVarId?: number;
 };

--- a/packages/emitter/src/emitter-types/index.ts
+++ b/packages/emitter/src/emitter-types/index.ts
@@ -14,6 +14,7 @@ export type {
   ExportMap,
   JsonAotRegistry,
   LocalTypeInfo,
+  NarrowedBinding,
 } from "./core.js";
 export type {
   CSharpAccessModifier,

--- a/packages/emitter/src/expressions/identifiers.ts
+++ b/packages/emitter/src/expressions/identifiers.ts
@@ -34,11 +34,18 @@ export const emitIdentifier = (
     return [{ text: "default" }, context];
   }
 
-  // Narrowing remap (e.g., account -> account__1_3 inside type guard then-branch)
+  // Narrowing remap for union type guards
+  // - "rename": account -> account__1_3 (if-statements with temp var)
+  // - "expr": account -> (account.As1()) (ternary expressions, inline)
   if (context.narrowedBindings) {
     const narrowed = context.narrowedBindings.get(expr.name);
     if (narrowed) {
-      return [{ text: escapeCSharpIdentifier(narrowed.name) }, context];
+      if (narrowed.kind === "rename") {
+        return [{ text: escapeCSharpIdentifier(narrowed.name) }, context];
+      } else {
+        // kind === "expr" - emit expression text verbatim (no escaping)
+        return [{ text: narrowed.exprText }, context];
+      }
     }
   }
 

--- a/packages/emitter/src/statements/control/conditionals.ts
+++ b/packages/emitter/src/statements/control/conditionals.ts
@@ -3,7 +3,13 @@
  */
 
 import { IrExpression, IrStatement, IrType } from "@tsonic/frontend";
-import { EmitterContext, getIndent, indent, dedent } from "../../types.js";
+import {
+  EmitterContext,
+  getIndent,
+  indent,
+  dedent,
+  NarrowedBinding,
+} from "../../types.js";
 import { emitExpression } from "../../expression-emitter.js";
 import { emitStatement } from "../../statement-emitter.js";
 import {
@@ -25,10 +31,7 @@ type GuardInfo = {
   readonly narrowedName: string;
   readonly escapedOrig: string;
   readonly escapedNarrow: string;
-  readonly narrowedMap: Map<
-    string,
-    { readonly name: string; readonly type?: IrType }
-  >;
+  readonly narrowedMap: Map<string, NarrowedBinding>;
 };
 
 /**
@@ -76,6 +79,7 @@ const tryResolvePredicateGuard = (
 
   const narrowedMap = new Map(ctxWithId.narrowedBindings ?? []);
   narrowedMap.set(originalName, {
+    kind: "rename",
     name: narrowedName,
     type: narrowing.targetType,
   });

--- a/packages/emitter/src/types.ts
+++ b/packages/emitter/src/types.ts
@@ -19,6 +19,7 @@ export type {
   ExportMap,
   JsonAotRegistry,
   LocalTypeInfo,
+  NarrowedBinding,
 } from "./emitter-types/index.js";
 export {
   createContext,

--- a/packages/emitter/testcases/functions/type-guards-ternary/TypeGuardsTernary.cs
+++ b/packages/emitter/testcases/functions/type-guards-ternary/TypeGuardsTernary.cs
@@ -1,0 +1,47 @@
+namespace TestCases.functions.typeguardsternary
+{
+    public class User
+    {
+        public string kind { get; set; }
+
+        public string username { get; set; }
+
+        public string email { get; set; }
+    }
+    public class Admin
+    {
+        public string kind { get; set; }
+
+        public double adminId { get; set; }
+    }
+
+            public static class TypeGuardsTernary
+            {
+                // type Account = global::Tsonic.Runtime.Union<User, Admin>
+
+                public static bool isUser(Account account)
+                    {
+                    return account.kind == "user";
+                    }
+
+                public static string nameOrAnon(Account a)
+                    {
+                    return a.Is1() ? (a.As1()).username : "anon";
+                    }
+
+                public static string adminOrUser(Account a)
+                    {
+                    return !a.Is1() ? "Admin" : (a.As1()).username;
+                    }
+
+                public static string getEmailOrDefault(Account a)
+                    {
+                    return a.Is1() ? (a.As1()).email : "no-email";
+                    }
+
+                public static string getUsernameUpper(Account a)
+                    {
+                    return a.Is1() ? global::Tsonic.JSRuntime.String.toUpperCase((a.As1()).username) : "ANON";
+                    }
+            }
+}

--- a/packages/emitter/testcases/functions/type-guards-ternary/TypeGuardsTernary.ts
+++ b/packages/emitter/testcases/functions/type-guards-ternary/TypeGuardsTernary.ts
@@ -1,0 +1,37 @@
+export interface User {
+  kind: "user";
+  username: string;
+  email: string;
+}
+
+export interface Admin {
+  kind: "admin";
+  adminId: number;
+}
+
+export type Account = User | Admin;
+
+// Type guard function
+export function isUser(account: Account): account is User {
+  return account.kind === "user";
+}
+
+// Case 1: Positive guard - narrow whenTrue branch
+export function nameOrAnon(a: Account): string {
+  return isUser(a) ? a.username : "anon";
+}
+
+// Case 2: Negated guard - narrow whenFalse branch
+export function adminOrUser(a: Account): string {
+  return !isUser(a) ? "Admin" : a.username;
+}
+
+// Case 3: Nested member access in narrowed branch
+export function getEmailOrDefault(a: Account): string {
+  return isUser(a) ? a.email : "no-email";
+}
+
+// Case 4: Method call in narrowed branch
+export function getUsernameUpper(a: Account): string {
+  return isUser(a) ? a.username.toUpperCase() : "ANON";
+}

--- a/packages/emitter/testcases/functions/type-guards-ternary/config.yaml
+++ b/packages/emitter/testcases/functions/type-guards-ternary/config.yaml
@@ -1,0 +1,1 @@
+- TypeGuardsTernary.ts: should emit ternary narrowing with inline AsN() calls


### PR DESCRIPTION
Extends the union narrowing system to handle ternary expressions:
- `isUser(x) ? x.name : "anon"` → `x.Is1() ? (x.As1()).name : "anon"`
- `!isUser(x) ? "anon" : x.name` → `!x.Is1() ? "anon" : (x.As1()).name`

Implementation:
- Add NarrowedBinding discriminated union type with two variants:
  - "rename": Used in if-statements (var x__1 = x.As1())
  - "expr": Used in ternary expressions (inline x.AsN() call)
- Update emitIdentifier to handle both binding kinds
- Add tryResolveTernaryGuard helper to detect predicate guards
- Patch emitConditional to apply inline narrowing per branch

Key design decision: In expressions we can't inject variable declarations, so we use inline expression replacement (x → (x.As1())) instead of the temp variable approach used in if-statements.

Adds golden tests for ternary narrowing patterns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)