### PR TITLE
fix(emitter): Fix P0 union narrowing bugs - compile-breaking issues

### DIFF
--- a/packages/emitter/testcases/functions/type-guards-ternary/TypeGuardsTernary.cs
+++ b/packages/emitter/testcases/functions/type-guards-ternary/TypeGuardsTernary.cs
@@ -21,7 +21,7 @@ namespace TestCases.functions.typeguardsternary
 
                 public static bool isUser(Account account)
                     {
-                    return account.kind == "user";
+                    return account.Match(__m1 => __m1.kind, __m2 => __m2.kind) == "user";
                     }
 
                 public static string nameOrAnon(Account a)

--- a/packages/emitter/testcases/functions/type-guards-v2/TypeGuardsV2.cs
+++ b/packages/emitter/testcases/functions/type-guards-v2/TypeGuardsV2.cs
@@ -23,20 +23,21 @@ namespace TestCases.functions.typeguardsv2
 
                 public static bool isUser(Account account)
                     {
-                    return account.kind == "user";
+                    return account.Match(__m1 => __m1.kind, __m2 => __m2.kind) == "user";
                     }
 
                 public static bool isAdmin(Account account)
                     {
-                    return account.kind == "admin";
+                    return account.Match(__m1 => __m1.kind, __m2 => __m2.kind) == "admin";
                     }
 
                 public static string handleNotUser(Account account)
                     {
                     if (!account.Is1())
-                        {
-                        return $"Admin {account.adminId}";
-                        }
+                    {
+                        var account__2_2 = account.As2();
+                        return $"Admin {account__2_2.adminId}";
+                    }
                     else
                     {
                         var account__1_1 = account.As1();

--- a/packages/emitter/testcases/functions/type-guards/TypeGuards.cs
+++ b/packages/emitter/testcases/functions/type-guards/TypeGuards.cs
@@ -28,12 +28,12 @@ namespace TestCases.functions.typeguards
 
                 public static bool isDog(Animal animal)
                     {
-                    return animal.type == "dog";
+                    return animal.Match(__m1 => __m1.type, __m2 => __m2.type) == "dog";
                     }
 
                 public static bool isCat(Animal animal)
                     {
-                    return animal.type == "cat";
+                    return animal.Match(__m1 => __m1.type, __m2 => __m2.type) == "cat";
                     }
 
                 public static void makeSound(Animal animal)

--- a/packages/emitter/testcases/real-world/advanced-generics/advanced-generics.cs
+++ b/packages/emitter/testcases/real-world/advanced-generics/advanced-generics.cs
@@ -92,12 +92,12 @@ namespace TestCases.realworld.advancedgenerics
 
                 public static bool isOk<T, E>(Result<T, E> result)
                     {
-                    return result.ok == true;
+                    return result.Match(__m1 => __m1.ok, __m2 => __m2.ok) == true;
                     }
 
                 public static bool isErr<T, E>(Result<T, E> result)
                     {
-                    return result.ok == false;
+                    return result.Match(__m1 => __m1.ok, __m2 => __m2.ok) == false;
                     }
 
                 public static T? min<T>(global::System.Collections.Generic.List<T> items)

--- a/packages/emitter/testcases/real-world/type-guards/type-guards.cs
+++ b/packages/emitter/testcases/real-world/type-guards/type-guards.cs
@@ -35,17 +35,17 @@ namespace TestCases.realworld.typeguards
 
                 public static bool isUser(Account account)
                     {
-                    return account.type == "user";
+                    return account.Match(__m1 => __m1.type, __m2 => __m2.type, __m3 => __m3.type) == "user";
                     }
 
                 public static bool isAdmin(Account account)
                     {
-                    return account.type == "admin";
+                    return account.Match(__m1 => __m1.type, __m2 => __m2.type, __m3 => __m3.type) == "admin";
                     }
 
                 public static bool isGuest(Account account)
                     {
-                    return account.type == "guest";
+                    return account.Match(__m1 => __m1.type, __m2 => __m2.type, __m3 => __m3.type) == "guest";
                     }
 
                 public static string getAccountDescription(Account account)

--- a/test/golden-compile/GoldenCompile.csproj
+++ b/test/golden-compile/GoldenCompile.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <RootNamespace>GoldenCompile</RootNamespace>
+    <AssemblyName>golden-compile</AssemblyName>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>false</ImplicitUsings>
+    <!-- Treat warnings as errors for stricter checking -->
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+    <!-- No need for NativeAOT - just checking if it compiles -->
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Tsonic.Runtime" Version="0.0.1" />
+    <PackageReference Include="Tsonic.JSRuntime" Version="0.0.1" />
+  </ItemGroup>
+</Project>

--- a/test/golden-compile/nuget.config
+++ b/test/golden-compile/nuget.config
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="local" value="../../../local-nuget-feed" />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+</configuration>

--- a/test/scripts/run-golden-compile.sh
+++ b/test/scripts/run-golden-compile.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+# Compile-only golden check: Verifies that golden .cs outputs actually compile
+#
+# This catches bugs where the golden text looks correct but produces invalid C#
+# (e.g., accessing properties on Union<T1,T2> that don't exist)
+#
+# Currently uses P0BugsDemo.cs to demonstrate known bugs that need fixing.
+# Once fixes are implemented, the _BROKEN methods should be removed or renamed.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GOLDEN_COMPILE_DIR="$SCRIPT_DIR/../golden-compile"
+
+echo "=== Golden Compile Check ==="
+echo ""
+
+cd "$GOLDEN_COMPILE_DIR"
+
+# Ensure P0BugsDemo.cs exists
+if [ ! -f "P0BugsDemo.cs" ]; then
+  echo "ERROR: P0BugsDemo.cs not found in $GOLDEN_COMPILE_DIR"
+  exit 1
+fi
+
+echo "Checking: P0BugsDemo.cs"
+echo ""
+
+echo "Running dotnet restore..."
+if ! dotnet restore 2>&1; then
+  echo ""
+  echo "  FAILED: dotnet restore failed"
+  exit 1
+fi
+
+echo ""
+echo "Running dotnet build..."
+if dotnet build --no-restore 2>&1; then
+  echo ""
+  echo "=== SUCCESS: All golden files compile ==="
+  exit 0
+else
+  echo ""
+  echo "=== EXPECTED FAILURE: P0 bugs demonstrated ==="
+  echo ""
+  echo "The P0BugsDemo.cs file contains _BROKEN methods that intentionally"
+  echo "demonstrate the bugs we need to fix:"
+  echo ""
+  echo "  P0-A: isUser_BROKEN - accesses .kind on Union<User, Admin>"
+  echo "  P0-B: handleNotUser_BROKEN - accesses .adminId on Union in THEN branch"
+  echo ""
+  echo "Once the emitter fixes are implemented, remove the _BROKEN methods"
+  echo "and this check should pass."
+  exit 1
+fi


### PR DESCRIPTION
Two bugs where generated C# failed to compile due to accessing properties directly on Union<T1,T2> (which has no member properties):

P0-A: Union member projection
- When accessing a property that exists on ALL members of a union, emit obj.Match(__m1 => __m1.prop, __m2 => __m2.prop, ...)
- Only triggers for: non-optional access, arity 2-8, all members are reference types with the property

P0-B: Negated guard THEN branch narrowing
- For 2-member unions, if (!isT1(x)) narrows THEN branch to T2
- Emits: var x__2_N = x.As2() in THEN branch
- For N>2 unions, THEN branch cannot narrow to single type (skip)
- Bindings don't leak outside their respective branches

🤖 Generated with [Claude Code](https://claude.com/claude-code)