### PR TITLE
feat(emitter): Add Map<K,V> and Set<T> support

### DIFF
--- a/packages/emitter/src/expressions/identifiers.ts
+++ b/packages/emitter/src/expressions/identifiers.ts
@@ -16,6 +16,8 @@ const RUNTIME_FALLBACKS: Record<string, string> = {
   console: "global::Tsonic.JSRuntime.console",
   Math: "global::Tsonic.JSRuntime.Math",
   JSON: "global::Tsonic.JSRuntime.JSON",
+  Map: "global::Tsonic.JSRuntime.Map",
+  Set: "global::Tsonic.JSRuntime.Set",
   parseInt: "global::Tsonic.JSRuntime.Globals.parseInt",
   parseFloat: "global::Tsonic.JSRuntime.Globals.parseFloat",
   isNaN: "global::Tsonic.JSRuntime.Globals.isNaN",

--- a/packages/emitter/src/types/references.ts
+++ b/packages/emitter/src/types/references.ts
@@ -155,10 +155,26 @@ export const emitReferenceType = (
     return ["global::System.Threading.Tasks.Task", context];
   }
 
+  // Map<K, V> → Tsonic.JSRuntime.Map<K, V>
+  if (name === "Map" && typeArguments && typeArguments.length === 2) {
+    const [keyArg, valueArg] = typeArguments;
+    if (keyArg && valueArg) {
+      const [keyType, ctx1] = emitType(keyArg, context);
+      const [valueType, ctx2] = emitType(valueArg, ctx1);
+      return [`global::Tsonic.JSRuntime.Map<${keyType}, ${valueType}>`, ctx2];
+    }
+  }
+
+  // Set<T> → Tsonic.JSRuntime.Set<T>
+  if (name === "Set" && typeArguments && typeArguments.length === 1) {
+    const firstArg = typeArguments[0];
+    if (firstArg) {
+      const [elementType, newContext] = emitType(firstArg, context);
+      return [`global::Tsonic.JSRuntime.Set<${elementType}>`, newContext];
+    }
+  }
+
   // Map common JS types to .NET equivalents
-  // Note: Date, RegExp, Map, Set are NOT SUPPORTED in MVP
-  // Users should use System.DateTime, System.Text.RegularExpressions.Regex,
-  // Dictionary<K,V>, and HashSet<T> directly
   const runtimeTypes: Record<string, string> = {
     Error: "System.Exception",
   };

--- a/packages/emitter/testcases/real-world/async-ops/async-ops.cs
+++ b/packages/emitter/testcases/real-world/async-ops/async-ops.cs
@@ -2,9 +2,9 @@ namespace TestCases.realworld.asyncops
 {
     public class AsyncCache<K, V>
     {
-        private Map<K, V> cache = new Map();
+        private global::Tsonic.JSRuntime.Map<K, V> cache = new global::Tsonic.JSRuntime.Map();
 
-        private Map<K, global::System.Threading.Tasks.Task<V>> loading = new Map();
+        private global::Tsonic.JSRuntime.Map<K, global::System.Threading.Tasks.Task<V>> loading = new global::Tsonic.JSRuntime.Map();
 
         public async global::System.Threading.Tasks.Task<V> get(K key, global::System.Func<global::System.Threading.Tasks.Task<V>> loader)
             {

--- a/packages/emitter/testcases/types/map-set/MapSet.cs
+++ b/packages/emitter/testcases/types/map-set/MapSet.cs
@@ -1,0 +1,36 @@
+namespace TestCases.types.mapset
+{
+        public static class MapSet
+        {
+            public static global::Tsonic.JSRuntime.Map<string, double> createStringMap()
+                {
+                return new global::Tsonic.JSRuntime.Map<string, double>();
+                }
+
+            public static global::Tsonic.JSRuntime.Set<double> createNumberSet()
+                {
+                return new global::Tsonic.JSRuntime.Set<double>();
+                }
+
+            public static double useMap(global::Tsonic.JSRuntime.Map<string, double> map)
+                {
+                map.set("a", 1.0);
+                map.set("b", 2.0);
+                var value = map.get("a");
+                var hasKey = map.has("a");
+                var deleted = map.delete("b");
+                var size = map.size;
+                return value ?? 0.0;
+                }
+
+            public static bool useSet(global::Tsonic.JSRuntime.Set<string> set)
+                {
+                set.add("hello");
+                set.add("world");
+                var hasValue = set.has("hello");
+                var deleted = set.delete("world");
+                var size = set.size;
+                return hasValue;
+                }
+        }
+}

--- a/packages/emitter/testcases/types/map-set/MapSet.ts
+++ b/packages/emitter/testcases/types/map-set/MapSet.ts
@@ -1,0 +1,30 @@
+// Map type declaration and usage
+export function createStringMap(): Map<string, number> {
+  return new Map<string, number>();
+}
+
+// Set type declaration and usage
+export function createNumberSet(): Set<number> {
+  return new Set<number>();
+}
+
+// Map operations
+export function useMap(map: Map<string, number>): number {
+  map.set("a", 1);
+  map.set("b", 2);
+  const value = map.get("a");
+  const hasKey = map.has("a");
+  const deleted = map.delete("b");
+  const size = map.size;
+  return value ?? 0;
+}
+
+// Set operations
+export function useSet(set: Set<string>): boolean {
+  set.add("hello");
+  set.add("world");
+  const hasValue = set.has("hello");
+  const deleted = set.delete("world");
+  const size = set.size;
+  return hasValue;
+}

--- a/packages/emitter/testcases/types/map-set/config.yaml
+++ b/packages/emitter/testcases/types/map-set/config.yaml
@@ -1,0 +1,1 @@
+- MapSet.ts: should emit Map and Set types using Tsonic.JSRuntime classes


### PR DESCRIPTION
Emit TypeScript Map and Set types as Tsonic.JSRuntime classes:
- Map<K, V> → global::Tsonic.JSRuntime.Map<K, V>
- Set<T> → global::Tsonic.JSRuntime.Set<T>

The runtime classes (in separate js-runtime project) provide full JS semantics with methods like .get(), .set(), .has(), .add(), .delete(), .size, etc.

Changes:
- references.ts: Add Map/Set type emission
- identifiers.ts: Add Map/Set to runtime fallbacks for new expressions

Tests:
- New golden test: types/map-set/MapSet.ts
- All 454 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)