### PR TITLE
chore: Use latest versions for all packages in init

### DIFF
--- a/npm/tsonic/package.json
+++ b/npm/tsonic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tsonic/tsonic",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "description": "TypeScript to C# to NativeAOT compiler",
   "type": "module",
   "bin": {

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -96,8 +96,8 @@ const getTypePackageInfo = (runtime: "js" | "dotnet"): TypePackageInfo => {
     return {
       packages: [
         CLI_PACKAGE,
-        { name: "@tsonic/js-globals", version: "0.1.1" },
-        { name: "@tsonic/types", version: "0.2.0" },
+        { name: "@tsonic/js-globals", version: "latest" },
+        { name: "@tsonic/types", version: "latest" },
       ],
       typeRoots: ["node_modules/@tsonic/js-globals"],
     };
@@ -110,8 +110,8 @@ const getTypePackageInfo = (runtime: "js" | "dotnet"): TypePackageInfo => {
   return {
     packages: [
       CLI_PACKAGE,
-      { name: "@tsonic/dotnet-globals", version: "0.1.2" },
-      { name: "@tsonic/dotnet", version: "0.5.1" },
+      { name: "@tsonic/dotnet-globals", version: "latest" },
+      { name: "@tsonic/dotnet", version: "latest" },
     ],
     typeRoots: ["node_modules/@tsonic/dotnet-globals"],
   };


### PR DESCRIPTION
- Change all type package versions to "latest" instead of hardcoded versions
- Ensures tsonic project init always gets the newest packages
- Bump @tsonic/tsonic to 0.1.16

🤖 Generated with [Claude Code](https://claude.com/claude-code)