### PR TITLE
fix: Update init template to use camelCase for @tsonic/dotnet

### DIFF
--- a/npm/tsonic/package.json
+++ b/npm/tsonic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tsonic/tsonic",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "description": "TypeScript to C# to NativeAOT compiler",
   "type": "module",
   "bin": {

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -41,9 +41,9 @@ const SAMPLE_MAIN_TS_DOTNET = `import { Console } from "@tsonic/dotnet/System";
 import { File } from "@tsonic/dotnet/System.IO";
 
 export function main(): void {
-  Console.WriteLine("Reading README.md...");
-  const content = File.ReadAllText("./README.md");
-  Console.WriteLine(content);
+  Console.writeLine("Reading README.md...");
+  const content = File.readAllText("./README.md");
+  Console.writeLine(content);
 }
 `;
 


### PR DESCRIPTION
The new @tsonic/dotnet@0.7.3 exports camelCase method names (e.g., writeLine, readAllText) that map to PascalCase CLR names via bindings. Update the dotnet init template to use the new API.

- Console.WriteLine → Console.writeLine
- File.ReadAllText → File.readAllText

Bump @tsonic/tsonic to 0.1.17

🤖 Generated with [Claude Code](https://claude.com/claude-code)