### PR TITLE
chore: Bump version to 0.0.10

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tsonic/cli",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "Command-line interface for Tsonic compiler",
   "type": "module",
   "main": "./dist/index.js",
@@ -27,7 +27,7 @@
   "dependencies": {
     "@tsonic/backend": "0.0.4",
     "@tsonic/emitter": "0.0.6",
-    "@tsonic/frontend": "0.0.4"
+    "@tsonic/frontend": "0.0.5"
   },
   "devDependencies": {
     "@types/chai": "5.2.2",

--- a/packages/cli/src/cli/constants.ts
+++ b/packages/cli/src/cli/constants.ts
@@ -2,4 +2,4 @@
  * CLI constants
  */
 
-export const VERSION = "0.0.9";
+export const VERSION = "0.0.10";

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tsonic/frontend",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "TypeScript parser and IR builder for Tsonic compiler",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
Includes fix for CLR bindings resolution with .js extension in import paths. The clr-bindings-resolver now correctly strips .js extension from subpaths when looking for bindings.json files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)