### PR TITLE
feat: Implement explicit array type emission for dotnet mode

### DIFF
--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -273,7 +273,7 @@ export const generateCommand = (
       };
     }
 
-    const { modules, entryModule } = graphResult.value;
+    const { modules, entryModule, bindings } = graphResult.value;
 
     // irResult.value was an array of modules, now it's graphResult.value.modules
     const irResult = { ok: true as const, value: modules };
@@ -285,6 +285,7 @@ export const generateCommand = (
       entryPointPath: absoluteEntryPoint,
       libraries: typeLibraries, // Only non-DLL libraries (type roots)
       runtime: config.runtime,
+      clrBindings: bindings, // Pass bindings from frontend for Action/Func resolution
     });
 
     if (!emitResult.ok) {

--- a/packages/emitter/src/emitter-types/core.ts
+++ b/packages/emitter/src/emitter-types/core.ts
@@ -4,6 +4,7 @@
 
 import type { MetadataFile } from "@tsonic/frontend/types/metadata.js";
 import type { TypeBinding } from "@tsonic/frontend/types/bindings.js";
+import type { TypeBinding as FrontendTypeBinding } from "@tsonic/frontend";
 import type {
   IrType,
   IrInterfaceMember,
@@ -74,6 +75,13 @@ export type EmitterOptions = {
   readonly exportMap?: ExportMap;
   /** JSON AOT registry for collecting types used with JsonSerializer (shared across modules) */
   readonly jsonAotRegistry?: JsonAotRegistry;
+  /**
+   * Pre-loaded CLR bindings from frontend (for Action/Func resolution).
+   * When provided, these take precedence over loading from library directories.
+   * The map keys are TypeScript emit names (e.g., "Action", "List").
+   * Values must have either `clrName` or `name` property containing the CLR type name.
+   */
+  readonly clrBindings?: ReadonlyMap<string, FrontendTypeBinding>;
 };
 
 /**

--- a/packages/emitter/src/expressions/calls.ts
+++ b/packages/emitter/src/expressions/calls.ts
@@ -314,17 +314,24 @@ export const emitCall = (
     }
   }
 
+  // Get parameter types from IR (extracted from resolved signature in frontend)
+  const parameterTypes = expr.parameterTypes ?? [];
+
   const args: string[] = [];
   for (let i = 0; i < expr.arguments.length; i++) {
     const arg = expr.arguments[i];
     if (!arg) continue; // Skip undefined (shouldn't happen in valid IR)
+
+    // Get expected type for this argument from parameter types
+    const expectedType = parameterTypes[i];
+
     if (arg.kind === "spread") {
       // Spread in function call
       const [spreadFrag, ctx] = emitExpression(arg.expression, currentContext);
       args.push(`params ${spreadFrag.text}`);
       currentContext = ctx;
     } else {
-      const [argFrag, ctx] = emitExpression(arg, currentContext);
+      const [argFrag, ctx] = emitExpression(arg, currentContext, expectedType);
       // Check if this argument needs ref/out/in prefix
       // Only add prefix if argument is an lvalue (identifier or member access)
       const passingMode = expr.argumentPassing?.[i];

--- a/packages/emitter/src/types/arrays.ts
+++ b/packages/emitter/src/types/arrays.ts
@@ -1,5 +1,11 @@
 /**
  * Array type emission
+ *
+ * In dotnet mode:
+ * - origin: "explicit" → emit native CLR array (T[])
+ * - origin: undefined → emit List<T>
+ *
+ * In js mode: always emit List<T> (JS semantics)
  */
 
 import { IrType } from "@tsonic/frontend";
@@ -7,13 +13,24 @@ import { EmitterContext } from "../types.js";
 import { emitType } from "./emitter.js";
 
 /**
- * Emit array types as global::System.Collections.Generic.List<T>
+ * Emit array types
+ *
+ * - Explicit T[] annotation in dotnet mode → native T[]
+ * - Otherwise → List<T>
  */
 export const emitArrayType = (
   type: Extract<IrType, { kind: "arrayType" }>,
   context: EmitterContext
 ): [string, EmitterContext] => {
   const [elementType, newContext] = emitType(type.elementType, context);
+  const runtime = context.options.runtime ?? "js";
+
+  // In dotnet mode with explicit array annotation, emit native CLR array
+  if (runtime === "dotnet" && type.origin === "explicit") {
+    return [`${elementType}[]`, newContext];
+  }
+
+  // Default: emit List<T> for JS semantics or inferred arrays
   return [
     `global::System.Collections.Generic.List<${elementType}>`,
     newContext,

--- a/packages/frontend/src/ir/type-converter/arrays.ts
+++ b/packages/frontend/src/ir/type-converter/arrays.ts
@@ -16,5 +16,6 @@ export const convertArrayType = (
   return {
     kind: "arrayType",
     elementType: convertType(node.elementType, checker),
+    origin: "explicit",
   };
 };

--- a/packages/frontend/src/ir/type-converter/orchestrator.ts
+++ b/packages/frontend/src/ir/type-converter/orchestrator.ts
@@ -64,6 +64,7 @@ export const convertType = (
           return {
             kind: "arrayType",
             elementType: convertType(firstElement.type.elementType, checker),
+            origin: "explicit",
           };
         }
       }

--- a/packages/frontend/src/ir/type-converter/references.ts
+++ b/packages/frontend/src/ir/type-converter/references.ts
@@ -25,6 +25,17 @@ export const convertTypeReference = (
     return getPrimitiveType(typeName);
   }
 
+  // Check for Array<T> utility type → convert to arrayType with explicit origin
+  // This ensures Array<T> and T[] are treated identically
+  const firstTypeArg = node.typeArguments?.[0];
+  if (typeName === "Array" && firstTypeArg) {
+    return {
+      kind: "arrayType",
+      elementType: convertType(firstTypeArg, checker),
+      origin: "explicit",
+    };
+  }
+
   // Check for Record<K, V> utility type → convert to IrDictionaryType
   const typeArgsForRecord = node.typeArguments;
   const keyTypeNode = typeArgsForRecord?.[0];

--- a/packages/frontend/src/ir/types/expressions.ts
+++ b/packages/frontend/src/ir/types/expressions.ts
@@ -127,6 +127,8 @@ export type IrCallExpression = {
   readonly typeArguments?: readonly IrType[]; // Explicit or inferred type arguments
   readonly requiresSpecialization?: boolean; // Flag for conditional/unsupported patterns
   readonly argumentPassing?: readonly ("value" | "ref" | "out" | "in")[]; // Passing mode for each argument
+  /** Parameter types from resolved signature (for expectedType threading to array literals etc.) */
+  readonly parameterTypes?: readonly (IrType | undefined)[];
   /** Type predicate narrowing metadata (for `x is T` predicates) */
   readonly narrowing?: {
     readonly kind: "typePredicate";

--- a/packages/frontend/src/ir/types/ir-types.ts
+++ b/packages/frontend/src/ir/types/ir-types.ts
@@ -48,6 +48,15 @@ export type IrTypeParameterType = {
 export type IrArrayType = {
   readonly kind: "arrayType";
   readonly elementType: IrType;
+  /**
+   * Set to "explicit" when the array type came from an explicit T[] annotation.
+   * Undefined when the type was inferred.
+   *
+   * In dotnet mode:
+   * - origin: "explicit" → emit native CLR array (T[])
+   * - origin: undefined → emit List<T>
+   */
+  readonly origin?: "explicit";
 };
 
 /**

--- a/packages/frontend/src/program.ts
+++ b/packages/frontend/src/program.ts
@@ -5,6 +5,7 @@
 
 export type { CompilerOptions, TsonicProgram } from "./program/index.js";
 export type { ModuleDependencyGraphResult } from "./program/dependency-graph.js";
+export type { TypeBinding } from "./program/index.js";
 export {
   createProgram,
   getSourceFile,

--- a/packages/frontend/src/program/dependency-graph.ts
+++ b/packages/frontend/src/program/dependency-graph.ts
@@ -11,12 +11,14 @@ import { IrModule } from "../ir/types.js";
 import { buildIrModule } from "../ir/builder/orchestrator.js";
 import { createProgram, createCompilerOptions } from "./creation.js";
 import { CompilerOptions, TsonicProgram } from "./types.js";
-import { loadAllDiscoveredBindings } from "./bindings.js";
+import { loadAllDiscoveredBindings, TypeBinding } from "./bindings.js";
 import { validateIrSoundness } from "../ir/validation/soundness-gate.js";
 
 export type ModuleDependencyGraphResult = {
   readonly modules: readonly IrModule[];
   readonly entryModule: IrModule;
+  /** Type bindings loaded from CLR packages (for emitter bindingsRegistry) */
+  readonly bindings: ReadonlyMap<string, TypeBinding>;
 };
 
 /**
@@ -326,5 +328,6 @@ export const buildModuleDependencyGraph = (
   return ok({
     modules,
     entryModule,
+    bindings: tsonicProgram.bindings.getTypesMap(),
   });
 };

--- a/packages/frontend/src/program/index.ts
+++ b/packages/frontend/src/program/index.ts
@@ -5,7 +5,7 @@
 export type { CompilerOptions, TsonicProgram, RuntimeMode } from "./types.js";
 export { defaultTsConfig } from "./config.js";
 export { loadDotnetMetadata } from "./metadata.js";
-export { BindingRegistry, loadBindings } from "./bindings.js";
+export { BindingRegistry, loadBindings, type TypeBinding } from "./bindings.js";
 export {
   collectTsDiagnostics,
   convertTsDiagnostic,


### PR DESCRIPTION
Implements Alice's proposal for distinguishing explicitly-annotated array types from inferred arrays. This enables proper CLR native array emission when the developer explicitly writes `T[]` or `Array<T>` syntax.

## Problem

Before this change, all arrays emitted as `List<T>` in dotnet mode:

```typescript
// TypeScript
const results: number[] = [0, 0, 0];
Parallel.invoke([() => worker1(), () => worker2()]);
```

```csharp
// Generated C# (WRONG)
var results = new List<double> { 0.0, 0.0, 0.0 };
Parallel.Invoke(new List<Action> { ... });  // Compile error!
```

`Parallel.Invoke` expects `Action[]`, not `List<Action>`.

## Solution

Track array type origin through the compilation pipeline:

### 1. IR Type Extension

Added `origin?: "explicit"` to `IrArrayType`:

```typescript
export type IrArrayType = {
  readonly kind: "arrayType";
  readonly elementType: IrType;
  readonly origin?: "explicit";  // NEW: tracks explicit T[] annotation
};
```

### 2. Frontend Type Conversion

Set `origin: "explicit"` when converting explicit array syntax:

- `T[]` syntax in arrays.ts
- `Array<T>` syntax in references.ts
- Rest parameters in orchestrator.ts

### 3. Parameter Type Extraction

Extract parameter types from resolved signatures to thread expectedType:

- Added `extractParameterTypes()` in frontend calls.ts
- Added `parameterTypes` field to `IrCallExpression`
- Preserves `origin: "explicit"` for array parameters

### 4. Emitter Changes

- `emitArrayType`: Returns `T[]` for explicit origin, `List<T>` for inferred
- `emitArray`: Emits `new T[] {...}` when expectedType has explicit origin
- `emitCall`: Threads `parameterTypes[i]` as expectedType to arguments

## Results

```typescript
// TypeScript
const results: number[] = [0, 0, 0];
Parallel.invoke([() => worker1(), () => worker2()]);
```

```csharp
// Generated C# (CORRECT)
double[] results = new double[] { 0.0, 0.0, 0.0 };
Parallel.Invoke(new global::System.Action[] { ... });
```

## Supporting Changes: CLR Bindings Passthrough

To properly resolve `Action[]` parameter types, bindings must flow from frontend to emitter:

- Added `clrBindings` option to `EmitterOptions`
- `buildModuleDependencyGraph` now returns bindings map
- `generate` command passes bindings to emitter
- Fixed arity-suffix indexing: non-generic `Action` takes precedence over `Action_9` (which would resolve to `System.Action`9`)

## Test Results

Multithreading example with Parallel.Invoke runs successfully:
- 3 workers ran in parallel on 32 processors
- Each computed sum(0..99999) = 4,999,950,000
- Total: 14,999,850,000

All E2E tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)