### PR TITLE
feat: Add for-await support with await foreach emission

### DIFF
--- a/packages/emitter/src/statements/control/loops.ts
+++ b/packages/emitter/src/statements/control/loops.ts
@@ -233,6 +233,12 @@ export const emitForStatement = (
 
 /**
  * Emit a for-of statement
+ *
+ * TypeScript: for (const x of items) { ... }
+ * C#: foreach (var x in items) { ... }
+ *
+ * TypeScript: for await (const x of asyncItems) { ... }
+ * C#: await foreach (var x in asyncItems) { ... }
  */
 export const emitForOfStatement = (
   stmt: Extract<IrStatement, { kind: "forOfStatement" }>,
@@ -243,11 +249,12 @@ export const emitForOfStatement = (
 
   const [bodyCode, bodyContext] = emitStatement(stmt.body, indent(exprContext));
 
-  // Use foreach in C#
+  // Use foreach in C#, with await prefix for async iteration
   const varName =
     stmt.variable.kind === "identifierPattern"
       ? escapeCSharpIdentifier(stmt.variable.name)
       : "item";
-  const code = `${ind}foreach (var ${varName} in ${exprFrag.text})\n${bodyCode}`;
+  const foreachKeyword = stmt.isAwait ? "await foreach" : "foreach";
+  const code = `${ind}${foreachKeyword} (var ${varName} in ${exprFrag.text})\n${bodyCode}`;
   return [code, dedent(bodyContext)];
 };

--- a/packages/emitter/src/statements/index.test.ts
+++ b/packages/emitter/src/statements/index.test.ts
@@ -248,6 +248,7 @@ describe("Statement Emission", () => {
                     },
                   ],
                 },
+                isAwait: false,
               },
             ],
           },
@@ -266,5 +267,157 @@ describe("Statement Emission", () => {
     expect(result).to.include("global::Tsonic.JSRuntime.console.log(item)");
     // Should NOT include using directives - uses global:: FQN
     expect(result).to.not.include("using Tsonic.JSRuntime");
+  });
+
+  it("should emit 'await foreach' when isAwait=true", () => {
+    const module: IrModule = {
+      kind: "module",
+      filePath: "/src/test.ts",
+      namespace: "MyApp",
+      className: "test",
+      isStaticContainer: true,
+      imports: [],
+      body: [
+        {
+          kind: "functionDeclaration",
+          name: "processAsync",
+          parameters: [
+            {
+              kind: "parameter",
+              pattern: { kind: "identifierPattern", name: "items" },
+              type: {
+                kind: "referenceType",
+                name: "IAsyncEnumerable",
+                typeArguments: [{ kind: "primitiveType", name: "string" }],
+              },
+              isOptional: false,
+              isRest: false,
+              passing: "value",
+            },
+          ],
+          returnType: {
+            kind: "referenceType",
+            name: "Task",
+            typeArguments: [],
+          },
+          body: {
+            kind: "blockStatement",
+            statements: [
+              {
+                kind: "forOfStatement",
+                variable: { kind: "identifierPattern", name: "item" },
+                expression: { kind: "identifier", name: "items" },
+                body: {
+                  kind: "blockStatement",
+                  statements: [
+                    {
+                      kind: "expressionStatement",
+                      expression: {
+                        kind: "call",
+                        callee: {
+                          kind: "memberAccess",
+                          object: { kind: "identifier", name: "console" },
+                          property: "log",
+                          isComputed: false,
+                          isOptional: false,
+                        },
+                        arguments: [{ kind: "identifier", name: "item" }],
+                        isOptional: false,
+                      },
+                    },
+                  ],
+                },
+                isAwait: true,
+              },
+            ],
+          },
+          isExported: true,
+          isAsync: true,
+          isGenerator: false,
+        },
+      ],
+      exports: [],
+    };
+
+    const result = emitModule(module);
+
+    // Should emit 'await foreach' for async iteration
+    expect(result).to.include("await foreach (var item in items)");
+    // Should NOT include regular 'foreach' (without await)
+    expect(result).to.not.match(/[^t]\sforeach\s/);
+  });
+
+  it("should emit regular 'foreach' when isAwait=false", () => {
+    const module: IrModule = {
+      kind: "module",
+      filePath: "/src/test.ts",
+      namespace: "MyApp",
+      className: "test",
+      isStaticContainer: true,
+      imports: [],
+      body: [
+        {
+          kind: "functionDeclaration",
+          name: "processSync",
+          parameters: [
+            {
+              kind: "parameter",
+              pattern: { kind: "identifierPattern", name: "items" },
+              type: {
+                kind: "referenceType",
+                name: "IEnumerable",
+                typeArguments: [{ kind: "primitiveType", name: "string" }],
+              },
+              isOptional: false,
+              isRest: false,
+              passing: "value",
+            },
+          ],
+          returnType: { kind: "voidType" },
+          body: {
+            kind: "blockStatement",
+            statements: [
+              {
+                kind: "forOfStatement",
+                variable: { kind: "identifierPattern", name: "item" },
+                expression: { kind: "identifier", name: "items" },
+                body: {
+                  kind: "blockStatement",
+                  statements: [
+                    {
+                      kind: "expressionStatement",
+                      expression: {
+                        kind: "call",
+                        callee: {
+                          kind: "memberAccess",
+                          object: { kind: "identifier", name: "console" },
+                          property: "log",
+                          isComputed: false,
+                          isOptional: false,
+                        },
+                        arguments: [{ kind: "identifier", name: "item" }],
+                        isOptional: false,
+                      },
+                    },
+                  ],
+                },
+                isAwait: false,
+              },
+            ],
+          },
+          isExported: true,
+          isAsync: false,
+          isGenerator: false,
+        },
+      ],
+      exports: [],
+    };
+
+    const result = emitModule(module);
+
+    // Should emit regular 'foreach' for sync iteration
+    expect(result).to.include("foreach (var item in items)");
+    // Should NOT include 'await foreach'
+    expect(result).to.not.include("await foreach");
   });
 });

--- a/packages/frontend/src/ir/converters/statements/control/loops.ts
+++ b/packages/frontend/src/ir/converters/statements/control/loops.ts
@@ -74,6 +74,7 @@ export const convertForOfStatement = (
     variable,
     expression: convertExpression(node.expression, checker),
     body: body ?? { kind: "emptyStatement" },
+    isAwait: !!node.awaitModifier,
   };
 };
 

--- a/packages/frontend/src/ir/types/statements.ts
+++ b/packages/frontend/src/ir/types/statements.ts
@@ -186,6 +186,8 @@ export type IrForOfStatement = {
   readonly variable: IrPattern;
   readonly expression: IrExpression;
   readonly body: IrStatement;
+  /** True for `for await (... of ...)` - async iteration */
+  readonly isAwait: boolean;
 };
 
 export type IrSwitchStatement = {


### PR DESCRIPTION
- Add `isAwait: boolean` to `IrForOfStatement` type
- Update frontend converter to capture `node.awaitModifier`
- Update emitter to emit `await foreach` when `isAwait=true`
- Add unit tests for IR conversion (for-await vs regular for-of)
- Add emitter tests verifying await foreach output

TypeScript `for await (const x of items)` now correctly emits C# `await foreach (var x in items)` for async iteration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)