### PR TITLE
fix: Append __Alias suffix when emitting type alias references

### DIFF
--- a/packages/emitter/src/specialization/type-aliases.test.ts
+++ b/packages/emitter/src/specialization/type-aliases.test.ts
@@ -128,7 +128,7 @@ describe("Type Aliases (spec/16 §3)", () => {
 
     expect(result).to.include("public sealed class Node__Alias");
     expect(result).to.include("public string name { get; set; } = default!;");
-    // Self-reference should be nullable
-    expect(result).to.include("public Node? next { get; set; } = default!;");
+    // Self-reference should use __Alias suffix and be nullable
+    expect(result).to.include("public Node__Alias? next { get; set; } = default!;");
   });
 });

--- a/packages/emitter/src/types/references.ts
+++ b/packages/emitter/src/types/references.ts
@@ -274,9 +274,19 @@ export const emitReferenceType = (
 
   // FALLTHROUGH is only permitted for local types.
   // Emitting a bare external name is unsound and forbidden.
-  if (context.localTypes?.has(name)) {
+  const localTypeInfo = context.localTypes?.get(name);
+  if (localTypeInfo) {
     // Convert nested type names (Outer$Inner → Outer.Inner)
-    const csharpName = isNestedType(name) ? tsCSharpNestedTypeName(name) : name;
+    let csharpName = isNestedType(name) ? tsCSharpNestedTypeName(name) : name;
+
+    // Type aliases with objectType underlying type are emitted as classes with __Alias suffix
+    // (per spec/16-types-and-interfaces.md §3.4)
+    if (
+      localTypeInfo.kind === "typeAlias" &&
+      localTypeInfo.type.kind === "objectType"
+    ) {
+      csharpName = `${csharpName}__Alias`;
+    }
 
     if (typeArguments && typeArguments.length > 0) {
       const typeParams: string[] = [];

--- a/test/fixtures/utility-types/expected/dotnet.txt
+++ b/test/fixtures/utility-types/expected/dotnet.txt
@@ -1,0 +1,7 @@
+Partial: name=Alice
+Person: name=Bob, age=30
+Pick: name=Diana
+Omit: name=Eve, age=35
+Required: name=Frank, age=40
+Partial<Partial>: name=Grace
+All utility type tests passed!

--- a/test/fixtures/utility-types/package-lock.json
+++ b/test/fixtures/utility-types/package-lock.json
@@ -1,0 +1,37 @@
+{
+  "name": "tsonic-e2e-test",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "tsonic-e2e-test",
+      "version": "1.0.0",
+      "dependencies": {
+        "@tsonic/dotnet": "^0.7.4",
+        "@tsonic/dotnet-globals": "^0.1.4"
+      }
+    },
+    "node_modules/@tsonic/dotnet": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/@tsonic/dotnet/-/dotnet-0.7.4.tgz",
+      "integrity": "sha512-tHQ7t0wkMNNUD7CCBjWJMA13lRz/kZ0btu+CPwrg9DrIIeQSC/K58euvw2mfqhTOZMvuPMN3FDrtwxOJkH226A==",
+      "license": "MIT",
+      "dependencies": {
+        "@tsonic/types": "^0.2.0"
+      }
+    },
+    "node_modules/@tsonic/dotnet-globals": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@tsonic/dotnet-globals/-/dotnet-globals-0.1.4.tgz",
+      "integrity": "sha512-zXdJk87XuegbMWPqlF7gfwivZWwtBxBNyaYY5Y7jwEPlgS4wRANfNX8wcpJxMTc9hlYmX52pVvuwjRIfza09wQ==",
+      "license": "MIT"
+    },
+    "node_modules/@tsonic/types": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@tsonic/types/-/types-0.2.1.tgz",
+      "integrity": "sha512-yGrGybbDXZB0+wTmciDTWizgewXI+24dUkItsKHJMc5Vl627AsX/HUziK2dPIhaOl7trS+AR/PayGrVd++6u7w==",
+      "license": "MIT"
+    }
+  }
+}

--- a/test/fixtures/utility-types/package.json
+++ b/test/fixtures/utility-types/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "tsonic-e2e-test",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "@tsonic/dotnet": "^0.7.4",
+    "@tsonic/dotnet-globals": "^0.1.4"
+  }
+}

--- a/test/fixtures/utility-types/src/index.ts
+++ b/test/fixtures/utility-types/src/index.ts
@@ -1,0 +1,51 @@
+// E2E test for utility types: Partial, Required, Pick, Omit
+import { Console } from "@tsonic/dotnet/System";
+
+interface Person {
+  name: string;
+  age: number;
+  email: string;
+}
+
+// Type aliases using utility types
+type PartialPerson = Partial<Person>;
+type NameOnly = Pick<Person, "name">;
+type WithoutEmail = Omit<Person, "email">;
+
+// Interface with optional properties
+interface OptionalFields {
+  name?: string;
+  age?: number;
+}
+type AllRequired = Required<OptionalFields>;
+
+// Nested utility types
+type PartialPartial = Partial<Partial<Person>>;
+
+export function main(): void {
+  // Test Partial<T> - all properties optional
+  const partial: PartialPerson = { name: "Alice" };
+  Console.writeLine(`Partial: name=${partial.name}`);
+
+  // Test full person
+  const person: Person = { name: "Bob", age: 30, email: "bob@example.com" };
+  Console.writeLine(`Person: name=${person.name}, age=${person.age}`);
+
+  // Test Pick<T, K> - only name property
+  const nameOnly: NameOnly = { name: "Diana" };
+  Console.writeLine(`Pick: name=${nameOnly.name}`);
+
+  // Test Omit<T, K> - without email
+  const withoutEmail: WithoutEmail = { name: "Eve", age: 35 };
+  Console.writeLine(`Omit: name=${withoutEmail.name}, age=${withoutEmail.age}`);
+
+  // Test Required<T> on optional fields
+  const allReq: AllRequired = { name: "Frank", age: 40 };
+  Console.writeLine(`Required: name=${allReq.name}, age=${allReq.age}`);
+
+  // Test nested: Partial<Partial<T>>
+  const partialPartial: PartialPartial = { name: "Grace" };
+  Console.writeLine(`Partial<Partial>: name=${partialPartial.name}`);
+
+  Console.writeLine("All utility type tests passed!");
+}

--- a/test/fixtures/utility-types/tsonic.dotnet.json
+++ b/test/fixtures/utility-types/tsonic.dotnet.json
@@ -1,0 +1,8 @@
+{
+  "runtime": "dotnet",
+  "rootNamespace": "UtilityTypes",
+  "entryPoint": "src/index.ts",
+  "sourceRoot": "src",
+  "outputDirectory": "generated",
+  "outputName": "utility-types"
+}


### PR DESCRIPTION
Type alias references (e.g., `const p: PartialPerson`) were being emitted without the `__Alias` suffix, causing C# compilation errors since the actual generated type is `PartialPerson__Alias`.

- Add suffix check in emitReferenceType() for structural type aliases
- Update test expectation for self-referential type alias
- Add E2E test for utility types (Partial, Required, Pick, Omit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)