### PR TITLE
fix: Resolve TSN5110 false positive for int-typed interface properties

### DIFF
--- a/packages/backend/src/build-orchestrator.ts
+++ b/packages/backend/src/build-orchestrator.ts
@@ -13,13 +13,7 @@ import {
   readdirSync,
 } from "fs";
 import { join, dirname } from "path";
-import {
-  BuildOptions,
-  BuildResult,
-  BuildConfig,
-  EntryInfo,
-  NuGetPackage,
-} from "./types.js";
+import { BuildOptions, BuildResult, BuildConfig, EntryInfo } from "./types.js";
 import { generateCsproj } from "./project-generator.js";
 import { generateProgramCs } from "./program-generator.js";
 import { checkDotnetInstalled, detectRid, publishNativeAot } from "./dotnet.js";
@@ -149,20 +143,10 @@ export const buildNativeAot = (
       copyFileSync(projectCsproj, join(buildDir, csprojFilename));
     } else {
       // Generate temporary .csproj for build
-      // Tsonic.Runtime is ALWAYS required (for unions, typeof, structural)
-      // Tsonic.JSRuntime only when mode: "js" (for JS semantics)
-      const packages: NuGetPackage[] = [
-        { name: "Tsonic.Runtime", version: "0.0.1" },
-      ];
-      if (entryInfo.runtime === "js") {
-        packages.push({ name: "Tsonic.JSRuntime", version: "0.0.1" });
-      }
-
       const buildConfig: BuildConfig = {
         rootNamespace: options.namespace,
         outputName: options.outputName || "tsonic",
         dotnetVersion: options.dotnetVersion || "net10.0",
-        packages,
         outputConfig: {
           type: "executable",
           nativeAot: true,

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -11,7 +11,6 @@ export type {
   BuildResult,
   BuildConfig,
   EntryInfo,
-  NuGetPackage,
   DotnetResult,
   OutputType,
   OutputConfig,

--- a/packages/backend/src/project-generator.test.ts
+++ b/packages/backend/src/project-generator.test.ts
@@ -9,12 +9,11 @@ import { BuildConfig } from "./types.js";
 
 describe("Project Generator", () => {
   describe("generateCsproj", () => {
-    it("should generate basic executable .csproj without packages", () => {
+    it("should generate basic executable .csproj", () => {
       const config: BuildConfig = {
         rootNamespace: "TestApp",
         outputName: "test",
         dotnetVersion: "net10.0",
-        packages: [],
         outputConfig: {
           type: "executable",
           nativeAot: true,
@@ -39,14 +38,13 @@ describe("Project Generator", () => {
       );
     });
 
-    it("should include package references when provided", () => {
+    it("should include assembly references when provided", () => {
       const config: BuildConfig = {
         rootNamespace: "TestApp",
         outputName: "test",
         dotnetVersion: "net10.0",
-        packages: [
-          { name: "System.Text.Json", version: "8.0.0" },
-          { name: "Newtonsoft.Json", version: "13.0.3" },
+        assemblyReferences: [
+          { name: "Tsonic.Runtime", hintPath: "lib/Tsonic.Runtime.dll" },
         ],
         outputConfig: {
           type: "executable",
@@ -62,12 +60,8 @@ describe("Project Generator", () => {
 
       const result = generateCsproj(config);
 
-      expect(result).to.include(
-        '<PackageReference Include="System.Text.Json" Version="8.0.0"'
-      );
-      expect(result).to.include(
-        '<PackageReference Include="Newtonsoft.Json" Version="13.0.3"'
-      );
+      expect(result).to.include('<Reference Include="Tsonic.Runtime">');
+      expect(result).to.include("<HintPath>lib/Tsonic.Runtime.dll</HintPath>");
       expect(result).to.include(
         "<OptimizationPreference>Size</OptimizationPreference>"
       );
@@ -78,7 +72,6 @@ describe("Project Generator", () => {
         rootNamespace: "TestApp",
         outputName: "test",
         dotnetVersion: "net10.0",
-        packages: [],
         outputConfig: {
           type: "executable",
           nativeAot: true,
@@ -104,7 +97,6 @@ describe("Project Generator", () => {
         rootNamespace: "TestLib",
         outputName: "testlib",
         dotnetVersion: "net10.0",
-        packages: [],
         outputConfig: {
           type: "library",
           targetFrameworks: ["net8.0", "net9.0"],

--- a/packages/backend/src/project-generator.ts
+++ b/packages/backend/src/project-generator.ts
@@ -4,7 +4,6 @@
 
 import {
   BuildConfig,
-  NuGetPackage,
   OutputConfig,
   ExecutableConfig,
   LibraryConfig,
@@ -12,27 +11,6 @@ import {
   PackageMetadata,
   AssemblyReference,
 } from "./types.js";
-
-/**
- * Generate package references XML
- */
-const formatPackageReferences = (packages: readonly NuGetPackage[]): string => {
-  if (packages.length === 0) {
-    return "";
-  }
-
-  const refs = packages
-    .map(
-      (pkg) =>
-        `    <PackageReference Include="${pkg.name}" Version="${pkg.version}" />`
-    )
-    .join("\n");
-
-  return `
-  <ItemGroup>
-${refs}
-  </ItemGroup>`;
-};
 
 /**
  * Generate assembly references XML (for DLL files)
@@ -194,7 +172,6 @@ const generatePropertyGroup = (
  * Generate complete .csproj file content
  */
 export const generateCsproj = (config: BuildConfig): string => {
-  const packageRefs = formatPackageReferences(config.packages);
   const assemblyRefs = formatAssemblyReferences(
     config.assemblyReferences ?? []
   );
@@ -208,7 +185,7 @@ export const generateCsproj = (config: BuildConfig): string => {
   const propertyGroup = generatePropertyGroup(config, config.outputConfig);
 
   return `<Project Sdk="Microsoft.NET.Sdk">
-${propertyGroup}${packageRefs}${assemblyRefs}${runtimeRef}
+${propertyGroup}${assemblyRefs}${runtimeRef}
 </Project>
 `;
 };

--- a/packages/backend/src/types.ts
+++ b/packages/backend/src/types.ts
@@ -3,14 +3,6 @@
  */
 
 /**
- * NuGet package reference
- */
-export type NuGetPackage = {
-  readonly name: string;
-  readonly version: string;
-};
-
-/**
  * Output type taxonomy
  */
 export type OutputType = "executable" | "library" | "console-app";
@@ -86,7 +78,6 @@ export type BuildConfig = {
   readonly dotnetVersion: string;
   readonly runtimePath?: string;
   readonly assemblyReferences?: readonly AssemblyReference[];
-  readonly packages: readonly NuGetPackage[];
   readonly outputConfig: OutputConfig;
 };
 

--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -224,7 +224,6 @@ export const generateCommand = (
     rootNamespace,
     projectRoot,
     sourceRoot,
-    packages,
     typeRoots,
   } = config;
 
@@ -433,7 +432,6 @@ export const generateCommand = (
         dotnetVersion: config.dotnetVersion,
         runtimePath,
         assemblyReferences,
-        packages,
         outputConfig,
       };
 

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -258,7 +258,6 @@ const generateConfig = (
     outputName: "app",
     runtime: runtime,
     optimize: "speed",
-    packages: [],
     buildOptions: {
       stripSymbols: true,
       invariantGlobalization: true,

--- a/packages/cli/src/config.test.ts
+++ b/packages/cli/src/config.test.ts
@@ -118,33 +118,6 @@ describe("Config", () => {
       expect(result.optimize).to.equal("speed");
     });
 
-    it("should default packages to empty (runtime DLLs bundled separately)", () => {
-      const config: TsonicConfig = {
-        rootNamespace: "MyApp",
-      };
-
-      const result = resolveConfig(config, {}, "/project");
-      // Runtime DLLs are bundled with @tsonic/tsonic, not NuGet packages
-      expect(result.packages).to.deep.equal([]);
-    });
-
-    it("should include user-specified packages from config", () => {
-      const config: TsonicConfig = {
-        rootNamespace: "MyApp",
-        packages: [
-          { name: "System.Text.Json", version: "8.0.0" },
-          { name: "Newtonsoft.Json", version: "13.0.3" },
-        ],
-      };
-
-      const result = resolveConfig(config, {}, "/project");
-      // Only user-specified packages, no automatic runtime packages
-      expect(result.packages).to.deep.equal([
-        { name: "System.Text.Json", version: "8.0.0" },
-        { name: "Newtonsoft.Json", version: "13.0.3" },
-      ]);
-    });
-
     it("should default stripSymbols to true", () => {
       const config: TsonicConfig = {
         rootNamespace: "MyApp",
@@ -291,7 +264,6 @@ describe("Config", () => {
         rid: "linux-x64",
         dotnetVersion: "net9.0",
         optimize: "size",
-        packages: [{ name: "Package.Name", version: "1.0.0" }],
         buildOptions: {
           stripSymbols: false,
           invariantGlobalization: false,
@@ -321,9 +293,6 @@ describe("Config", () => {
       expect(result.rid).to.equal("win-x64");
       expect(result.dotnetVersion).to.equal("net9.0");
       expect(result.optimize).to.equal("speed");
-      expect(result.packages).to.deep.equal([
-        { name: "Package.Name", version: "1.0.0" },
-      ]);
       expect(result.stripSymbols).to.equal(false);
       expect(result.invariantGlobalization).to.equal(false);
       expect(result.keepTemp).to.equal(true);

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -191,9 +191,6 @@ export const resolveConfig = (
     dotnetVersion: config.dotnetVersion ?? "net10.0",
     optimize: cliOptions.optimize ?? config.optimize ?? "speed",
     runtime: config.runtime ?? "js",
-    // Only include user-specified packages
-    // Runtime DLLs are bundled with @tsonic/tsonic and added as assembly references
-    packages: config.dotnet?.packages ?? [],
     outputConfig,
     stripSymbols: cliOptions.noStrip
       ? false

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -2,11 +2,7 @@
  * Type definitions for CLI
  */
 
-import type {
-  NuGetPackage,
-  OutputType,
-  PackageMetadata,
-} from "@tsonic/backend";
+import type { OutputType, PackageMetadata } from "@tsonic/backend";
 
 /**
  * Output configuration in tsonic.json
@@ -51,7 +47,6 @@ export type TsonicConfig = {
   };
   readonly dotnet?: {
     readonly typeRoots?: readonly string[];
-    readonly packages?: readonly NuGetPackage[];
     readonly libraries?: readonly string[]; // External library paths for .NET interop
   };
 };
@@ -71,7 +66,6 @@ export type CliOptions = {
   optimize?: "size" | "speed";
   keepTemp?: boolean;
   noStrip?: boolean;
-  packages?: string;
   lib?: string[]; // External library paths for .NET interop
   // Project init options
   skipTypes?: boolean;
@@ -104,7 +98,6 @@ export type ResolvedConfig = {
   readonly dotnetVersion: string;
   readonly optimize: "size" | "speed";
   readonly runtime: "js" | "dotnet";
-  readonly packages: readonly NuGetPackage[];
   readonly outputConfig: TsonicOutputConfig;
   readonly stripSymbols: boolean;
   readonly invariantGlobalization: boolean;

--- a/packages/frontend/src/ir/type-converter/primitives.ts
+++ b/packages/frontend/src/ir/type-converter/primitives.ts
@@ -17,7 +17,7 @@ import { IrType, IrPrimitiveType } from "../types.js";
  * Note: Only "int" is currently supported as a distinct primitive.
  * Other CLR numerics remain as referenceType for now and are handled by the emitter.
  */
-const CLR_PRIMITIVE_TYPES = new Set(["int"]);
+export const CLR_PRIMITIVE_TYPE_SET = new Set(["int"]);
 
 /**
  * Convert TypeScript primitive keyword to IR type
@@ -63,7 +63,7 @@ export const isPrimitiveTypeName = (
  * These come from @tsonic/core and are compiler-known primitives.
  */
 export const isClrPrimitiveTypeName = (typeName: string): typeName is "int" => {
-  return CLR_PRIMITIVE_TYPES.has(typeName);
+  return CLR_PRIMITIVE_TYPE_SET.has(typeName);
 };
 
 /**

--- a/test/fixtures/object-prop-int-to-int/expected/dotnet.txt
+++ b/test/fixtures/object-prop-int-to-int/expected/dotnet.txt
@@ -1,0 +1,1 @@
+Created todo: Test todo

--- a/test/fixtures/object-prop-int-to-int/package-lock.json
+++ b/test/fixtures/object-prop-int-to-int/package-lock.json
@@ -1,0 +1,57 @@
+{
+  "name": "object-prop-int-to-int",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "object-prop-int-to-int",
+      "version": "1.0.0",
+      "dependencies": {
+        "@tsonic/core": "^0.2.0",
+        "@tsonic/dotnet": "^0.8.0",
+        "@tsonic/globals": "^0.3.3"
+      }
+    },
+    "node_modules/@tsonic/core": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@tsonic/core/-/core-0.2.0.tgz",
+      "integrity": "sha512-KW2DE4jmj/GYzGq1dfCxLHnLNeB/7ycpHIs5+gf8kMqxo5uwfB3EPYvKtR4FCDHPvLFAn4hQNW0LjyVX1RZ3jg==",
+      "license": "MIT"
+    },
+    "node_modules/@tsonic/dotnet": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@tsonic/dotnet/-/dotnet-0.8.0.tgz",
+      "integrity": "sha512-56Un/45p6gH853Ljfv+l7MAn7hulh2H18F1VDwJXZIKdcCa6of937RjXDwMizECA3DME1ij0LV+bSzDOMmzz6g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@tsonic/core": "*"
+      }
+    },
+    "node_modules/@tsonic/globals": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@tsonic/globals/-/globals-0.3.3.tgz",
+      "integrity": "sha512-4KjzWLdbonyvwdjjhORwK2KF+a3D1jt6MqXHwziwKdzqDy7NQ2wR2xD5WgkyOV+gFeRrWePW9VrZCLIAChNLIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tsonic/dotnet": "^0.7.9"
+      }
+    },
+    "node_modules/@tsonic/globals/node_modules/@tsonic/core": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@tsonic/core/-/core-0.1.2.tgz",
+      "integrity": "sha512-AE0AZ29gdA3kwI5qDcd+OxoPEyMAUHVxgYQ2uLQc9K1bj3W+2Erluut0iDXtrjCfJu9FD0lSg9TtVzsvjw+5Gw==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@tsonic/globals/node_modules/@tsonic/dotnet": {
+      "version": "0.7.9",
+      "resolved": "https://registry.npmjs.org/@tsonic/dotnet/-/dotnet-0.7.9.tgz",
+      "integrity": "sha512-edsicWNz3SZgsbu073DB5ZhCpNYRttIIkH7ohYYTe97DTfLID/e0PERFdF/FjY09/0btixU+I/+xCy//oYFSPA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@tsonic/core": "^0.1.1"
+      }
+    }
+  }
+}

--- a/test/fixtures/object-prop-int-to-int/package.json
+++ b/test/fixtures/object-prop-int-to-int/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "object-prop-int-to-int",
+  "version": "1.0.0",
+  "type": "module",
+  "private": true,
+  "dependencies": {
+    "@tsonic/core": "^0.2.0",
+    "@tsonic/globals": "^0.3.3",
+    "@tsonic/dotnet": "^0.8.0"
+  }
+}

--- a/test/fixtures/object-prop-int-to-int/src/index.ts
+++ b/test/fixtures/object-prop-int-to-int/src/index.ts
@@ -1,0 +1,33 @@
+// REGRESSION TEST: Interface property typed as 'int' should accept 'int' values
+//
+// This tests the fix for a bug where extractStructuralMembers was resolving
+// the `int` type alias to `number` (its underlying type), causing TSN5110
+// to incorrectly reject int→int assignments as int→double.
+//
+// The bug was: TypeScript's typeToTypeNode eagerly resolves aliases like `int`
+// to their underlying type `number`. The fix checks propType.aliasSymbol before
+// calling typeToTypeNode and preserves CLR primitive aliases from @tsonic/core.
+
+import { int } from "@tsonic/core/types.js";
+import { Console } from "@tsonic/dotnet/System";
+
+// Interface with int-typed property
+interface Todo {
+  id: int;
+  title: string;
+}
+
+// Create function returns Todo with id from int variable
+function createTodo(id: int, title: string): Todo {
+  // id is type 'int', Todo.id expects 'int'
+  // This SHOULD NOT trigger TSN5110 - int→int is valid
+  return {
+    id,
+    title,
+  };
+}
+
+export function main(): void {
+  const todo = createTodo(1 as int, "Test todo");
+  Console.writeLine("Created todo: " + todo.title);
+}

--- a/test/fixtures/object-prop-int-to-int/tsonic.dotnet.json
+++ b/test/fixtures/object-prop-int-to-int/tsonic.dotnet.json
@@ -1,0 +1,11 @@
+{
+  "runtime": "dotnet",
+  "rootNamespace": "ObjectPropIntToInt",
+  "entryPoint": "src/index.ts",
+  "sourceRoot": "src",
+  "outputDirectory": "generated",
+  "outputName": "object-prop-int-to-int",
+  "dotnet": {
+    "typeRoots": ["node_modules/@tsonic/globals"]
+  }
+}


### PR DESCRIPTION
- Fix type alias resolution in extractStructuralMembers to preserve `int` type from @tsonic/core instead of resolving to underlying `number`
- Use getSymbolAtLocation + getAliasedSymbol to trace import chain back to original type declaration in @tsonic/core
- Export CLR_PRIMITIVE_TYPE_SET from primitives.ts for use in references.ts
- Add regression test fixture: object-prop-int-to-int

Also removes unused dotnet.packages feature:
- Remove NuGetPackage type and packages from BuildConfig
- Remove formatPackageReferences from project-generator
- Remove packages from TsonicConfig, ResolvedConfig, CliOptions
- Remove packages handling from resolveConfig and generateCommand
- Update tests to remove package-related assertions

🤖 Generated with [Claude Code](https://claude.com/claude-code)