### PR TITLE
fix: Remove all non-null assertions to pass ESLint

### DIFF
--- a/packages/frontend/src/ir/type-converter/utility-types.test.ts
+++ b/packages/frontend/src/ir/type-converter/utility-types.test.ts
@@ -18,6 +18,17 @@ import {
 import { IrType } from "../types.js";
 
 /**
+ * Assert value is not null/undefined and return it typed as non-null.
+ * Throws if value is null or undefined.
+ */
+const assertDefined = <T>(value: T | null | undefined, msg?: string): T => {
+  if (value === null || value === undefined) {
+    throw new Error(msg ?? "Expected value to be defined");
+  }
+  return value;
+};
+
+/**
  * Helper to create a TypeScript program from source code
  */
 const createTestProgram = (
@@ -71,7 +82,10 @@ const createTestProgram = (
     name === fileName ? source : originalReadFile.call(host, name);
 
   const program = ts.createProgram([fileName], compilerOptions, host);
-  const sourceFile = program.getSourceFile(fileName)!;
+  const sourceFile = assertDefined(
+    program.getSourceFile(fileName),
+    `Source file ${fileName} not found`
+  );
   const checker = program.getTypeChecker();
 
   return { program, checker, sourceFile };
@@ -157,9 +171,8 @@ describe("Utility Type Expansion Safety", () => {
       const { checker, sourceFile } = createTestProgram(source);
       const typeRef = findTypeAliasReference(sourceFile, "PartialWithIndex");
 
-      expect(typeRef).not.to.equal(null);
       const result = expandUtilityType(
-        typeRef!,
+        assertDefined(typeRef, "typeRef should be defined"),
         "Partial",
         checker,
         stubConvertType
@@ -181,9 +194,8 @@ describe("Utility Type Expansion Safety", () => {
       const { checker, sourceFile } = createTestProgram(source);
       const typeRef = findTypeAliasReference(sourceFile, "ReadonlyWithIndex");
 
-      expect(typeRef).not.to.equal(null);
       const result = expandUtilityType(
-        typeRef!,
+        assertDefined(typeRef, "typeRef should be defined"),
         "Readonly",
         checker,
         stubConvertType
@@ -205,9 +217,8 @@ describe("Utility Type Expansion Safety", () => {
       const { checker, sourceFile } = createTestProgram(source);
       const typeRef = findTypeAliasReference(sourceFile, "PartialPerson");
 
-      expect(typeRef).not.to.equal(null);
       const result = expandUtilityType(
-        typeRef!,
+        assertDefined(typeRef, "typeRef should be defined"),
         "Partial",
         checker,
         stubConvertType
@@ -269,9 +280,8 @@ describe("Utility Type Expansion Safety", () => {
         "PartialWithUndefined"
       );
 
-      expect(typeRef).not.to.equal(null);
       const result = expandUtilityType(
-        typeRef!,
+        assertDefined(typeRef, "typeRef should be defined"),
         "Partial",
         checker,
         stubConvertType
@@ -309,9 +319,8 @@ describe("Utility Type Expansion Safety", () => {
         "PartialWithSynthetic"
       );
 
-      expect(typeRef).not.to.equal(null);
       const result = expandUtilityType(
-        typeRef!,
+        assertDefined(typeRef, "typeRef should be defined"),
         "Partial",
         checker,
         stubConvertType
@@ -347,9 +356,8 @@ describe("Utility Type Expansion Safety", () => {
       const { checker, sourceFile } = createTestProgram(source);
       const typeRef = findTypeAliasReference(sourceFile, "PartialRequired");
 
-      expect(typeRef).not.to.equal(null);
       const result = expandUtilityType(
-        typeRef!,
+        assertDefined(typeRef, "typeRef should be defined"),
         "Partial",
         checker,
         stubConvertType
@@ -381,9 +389,8 @@ describe("Utility Type Expansion Safety", () => {
       const { checker, sourceFile } = createTestProgram(source);
       const typeRef = findTypeAliasReference(sourceFile, "PartialReadonly");
 
-      expect(typeRef).not.to.equal(null);
       const result = expandUtilityType(
-        typeRef!,
+        assertDefined(typeRef, "typeRef should be defined"),
         "Partial",
         checker,
         stubConvertType
@@ -415,9 +422,8 @@ describe("Utility Type Expansion Safety", () => {
       const { checker, sourceFile } = createTestProgram(source);
       const typeRef = findTypeAliasReference(sourceFile, "ReadonlyPartial");
 
-      expect(typeRef).not.to.equal(null);
       const result = expandUtilityType(
-        typeRef!,
+        assertDefined(typeRef, "typeRef should be defined"),
         "Readonly",
         checker,
         stubConvertType
@@ -451,9 +457,8 @@ describe("Utility Type Expansion Safety", () => {
       const { checker, sourceFile } = createTestProgram(source);
       const typeRef = findTypeAliasReference(sourceFile, "PartialWithMethod");
 
-      expect(typeRef).not.to.equal(null);
       const result = expandUtilityType(
-        typeRef!,
+        assertDefined(typeRef, "typeRef should be defined"),
         "Partial",
         checker,
         stubConvertType
@@ -495,9 +500,8 @@ describe("Utility Type Expansion Safety", () => {
       const { checker, sourceFile } = createTestProgram(source);
       const typeRef = findTypeAliasReference(sourceFile, "ContactInfo");
 
-      expect(typeRef).not.to.equal(null);
       const result = expandUtilityType(
-        typeRef!,
+        assertDefined(typeRef, "typeRef should be defined"),
         "Pick",
         checker,
         stubConvertType
@@ -531,9 +535,8 @@ describe("Utility Type Expansion Safety", () => {
       const { checker, sourceFile } = createTestProgram(source);
       const typeRef = findTypeAliasReference(sourceFile, "MinimalPerson");
 
-      expect(typeRef).not.to.equal(null);
       const result = expandUtilityType(
-        typeRef!,
+        assertDefined(typeRef, "typeRef should be defined"),
         "Omit",
         checker,
         stubConvertType
@@ -576,9 +579,8 @@ describe("Utility Type Expansion Safety", () => {
       };
       ts.forEachChild(sourceFile, visitor);
 
-      expect(typeRef).not.to.equal(null);
       const result = expandUtilityType(
-        typeRef!,
+        assertDefined(typeRef, "typeRef should be defined"),
         "Partial",
         checker,
         stubConvertType
@@ -600,9 +602,8 @@ describe("Conditional Utility Type Expansion", () => {
       const { checker, sourceFile } = createTestProgram(source);
       const typeRef = findTypeAliasReference(sourceFile, "Result");
 
-      expect(typeRef).not.to.equal(null);
       const result = expandConditionalUtilityType(
-        typeRef!,
+        assertDefined(typeRef, "typeRef should be defined"),
         "NonNullable",
         checker,
         stubConvertType
@@ -623,9 +624,8 @@ describe("Conditional Utility Type Expansion", () => {
       const { checker, sourceFile } = createTestProgram(source);
       const typeRef = findTypeAliasReference(sourceFile, "Result");
 
-      expect(typeRef).not.to.equal(null);
       const result = expandConditionalUtilityType(
-        typeRef!,
+        assertDefined(typeRef, "typeRef should be defined"),
         "NonNullable",
         checker,
         stubConvertType
@@ -646,9 +646,8 @@ describe("Conditional Utility Type Expansion", () => {
       const { checker, sourceFile } = createTestProgram(source);
       const typeRef = findTypeAliasReference(sourceFile, "Result");
 
-      expect(typeRef).not.to.equal(null);
       const result = expandConditionalUtilityType(
-        typeRef!,
+        assertDefined(typeRef, "typeRef should be defined"),
         "NonNullable",
         checker,
         stubConvertType
@@ -666,9 +665,8 @@ describe("Conditional Utility Type Expansion", () => {
       const { checker, sourceFile } = createTestProgram(source);
       const typeRef = findTypeAliasReference(sourceFile, "Result");
 
-      expect(typeRef).not.to.equal(null);
       const result = expandConditionalUtilityType(
-        typeRef!,
+        assertDefined(typeRef, "typeRef should be defined"),
         "NonNullable",
         checker,
         stubConvertType
@@ -686,9 +684,8 @@ describe("Conditional Utility Type Expansion", () => {
       const { checker, sourceFile } = createTestProgram(source);
       const typeRef = findTypeAliasReference(sourceFile, "Result");
 
-      expect(typeRef).not.to.equal(null);
       const result = expandConditionalUtilityType(
-        typeRef!,
+        assertDefined(typeRef, "typeRef should be defined"),
         "NonNullable",
         checker,
         stubConvertType
@@ -718,9 +715,8 @@ describe("Conditional Utility Type Expansion", () => {
       };
       ts.forEachChild(sourceFile, visitor);
 
-      expect(typeRef).not.to.equal(null);
       const result = expandConditionalUtilityType(
-        typeRef!,
+        assertDefined(typeRef, "typeRef should be defined"),
         "NonNullable",
         checker,
         stubConvertType
@@ -739,9 +735,8 @@ describe("Conditional Utility Type Expansion", () => {
       const { checker, sourceFile } = createTestProgram(source);
       const typeRef = findTypeAliasReference(sourceFile, "Result");
 
-      expect(typeRef).not.to.equal(null);
       const result = expandConditionalUtilityType(
-        typeRef!,
+        assertDefined(typeRef, "typeRef should be defined"),
         "Exclude",
         checker,
         stubConvertType
@@ -761,9 +756,8 @@ describe("Conditional Utility Type Expansion", () => {
       const { checker, sourceFile } = createTestProgram(source);
       const typeRef = findTypeAliasReference(sourceFile, "Result");
 
-      expect(typeRef).not.to.equal(null);
       const result = expandConditionalUtilityType(
-        typeRef!,
+        assertDefined(typeRef, "typeRef should be defined"),
         "Exclude",
         checker,
         stubConvertType
@@ -784,9 +778,8 @@ describe("Conditional Utility Type Expansion", () => {
       const { checker, sourceFile } = createTestProgram(source);
       const typeRef = findTypeAliasReference(sourceFile, "Result");
 
-      expect(typeRef).not.to.equal(null);
       const result = expandConditionalUtilityType(
-        typeRef!,
+        assertDefined(typeRef, "typeRef should be defined"),
         "Exclude",
         checker,
         stubConvertType
@@ -816,9 +809,8 @@ describe("Conditional Utility Type Expansion", () => {
       };
       ts.forEachChild(sourceFile, visitor);
 
-      expect(typeRef).not.to.equal(null);
       const result = expandConditionalUtilityType(
-        typeRef!,
+        assertDefined(typeRef, "typeRef should be defined"),
         "Exclude",
         checker,
         stubConvertType
@@ -837,9 +829,8 @@ describe("Conditional Utility Type Expansion", () => {
       const { checker, sourceFile } = createTestProgram(source);
       const typeRef = findTypeAliasReference(sourceFile, "Result");
 
-      expect(typeRef).not.to.equal(null);
       const result = expandConditionalUtilityType(
-        typeRef!,
+        assertDefined(typeRef, "typeRef should be defined"),
         "Extract",
         checker,
         stubConvertType
@@ -857,9 +848,8 @@ describe("Conditional Utility Type Expansion", () => {
       const { checker, sourceFile } = createTestProgram(source);
       const typeRef = findTypeAliasReference(sourceFile, "Result");
 
-      expect(typeRef).not.to.equal(null);
       const result = expandConditionalUtilityType(
-        typeRef!,
+        assertDefined(typeRef, "typeRef should be defined"),
         "Extract",
         checker,
         stubConvertType
@@ -880,9 +870,8 @@ describe("Conditional Utility Type Expansion", () => {
       const { checker, sourceFile } = createTestProgram(source);
       const typeRef = findTypeAliasReference(sourceFile, "Result");
 
-      expect(typeRef).not.to.equal(null);
       const result = expandConditionalUtilityType(
-        typeRef!,
+        assertDefined(typeRef, "typeRef should be defined"),
         "Extract",
         checker,
         stubConvertType
@@ -902,9 +891,8 @@ describe("Conditional Utility Type Expansion", () => {
       const { checker, sourceFile } = createTestProgram(source);
       const typeRef = findTypeAliasReference(sourceFile, "Result");
 
-      expect(typeRef).not.to.equal(null);
       const result = expandConditionalUtilityType(
-        typeRef!,
+        assertDefined(typeRef, "typeRef should be defined"),
         "Exclude",
         checker,
         stubConvertType
@@ -922,9 +910,8 @@ describe("Conditional Utility Type Expansion", () => {
       const { checker, sourceFile } = createTestProgram(source);
       const typeRef = findTypeAliasReference(sourceFile, "Result");
 
-      expect(typeRef).not.to.equal(null);
       const result = expandConditionalUtilityType(
-        typeRef!,
+        assertDefined(typeRef, "typeRef should be defined"),
         "Extract",
         checker,
         stubConvertType
@@ -942,9 +929,8 @@ describe("Conditional Utility Type Expansion", () => {
       const { checker, sourceFile } = createTestProgram(source);
       const typeRef = findTypeAliasReference(sourceFile, "Result");
 
-      expect(typeRef).not.to.equal(null);
       const result = expandConditionalUtilityType(
-        typeRef!,
+        assertDefined(typeRef, "typeRef should be defined"),
         "Exclude",
         checker,
         stubConvertType
@@ -962,9 +948,8 @@ describe("Conditional Utility Type Expansion", () => {
       const { checker, sourceFile } = createTestProgram(source);
       const typeRef = findTypeAliasReference(sourceFile, "Result");
 
-      expect(typeRef).not.to.equal(null);
       const result = expandConditionalUtilityType(
-        typeRef!,
+        assertDefined(typeRef, "typeRef should be defined"),
         "Extract",
         checker,
         stubConvertType
@@ -982,9 +967,8 @@ describe("Conditional Utility Type Expansion", () => {
       const { checker, sourceFile } = createTestProgram(source);
       const typeRef = findTypeAliasReference(sourceFile, "Result");
 
-      expect(typeRef).not.to.equal(null);
       const result = expandConditionalUtilityType(
-        typeRef!,
+        assertDefined(typeRef, "typeRef should be defined"),
         "Exclude",
         checker,
         stubConvertType
@@ -1004,9 +988,8 @@ describe("Conditional Utility Type Expansion", () => {
       const { checker, sourceFile } = createTestProgram(source);
       const typeRef = findTypeAliasReference(sourceFile, "OnlyNumbers");
 
-      expect(typeRef).not.to.equal(null);
       const result = expandConditionalUtilityType(
-        typeRef!,
+        assertDefined(typeRef, "typeRef should be defined"),
         "Exclude",
         checker,
         stubConvertType
@@ -1028,9 +1011,8 @@ describe("Conditional Utility Type Expansion", () => {
       const { checker, sourceFile } = createTestProgram(source);
       const typeRef = findTypeAliasReference(sourceFile, "OnlyStrings");
 
-      expect(typeRef).not.to.equal(null);
       const result = expandConditionalUtilityType(
-        typeRef!,
+        assertDefined(typeRef, "typeRef should be defined"),
         "Extract",
         checker,
         stubConvertType
@@ -1050,9 +1032,8 @@ describe("Conditional Utility Type Expansion", () => {
       const { checker, sourceFile } = createTestProgram(source);
       const typeRef = findTypeAliasReference(sourceFile, "Result");
 
-      expect(typeRef).not.to.equal(null);
       const result = expandConditionalUtilityType(
-        typeRef!,
+        assertDefined(typeRef, "typeRef should be defined"),
         "Exclude",
         checker,
         stubConvertType
@@ -1075,9 +1056,8 @@ describe("Conditional Utility Type Expansion", () => {
       const { checker, sourceFile } = createTestProgram(source);
       const typeRef = findTypeAliasReference(sourceFile, "Result");
 
-      expect(typeRef).not.to.equal(null);
       const result = expandConditionalUtilityType(
-        typeRef!,
+        assertDefined(typeRef, "typeRef should be defined"),
         "ReturnType",
         checker,
         stubConvertType
@@ -1098,9 +1078,8 @@ describe("Conditional Utility Type Expansion", () => {
       const { checker, sourceFile } = createTestProgram(source);
       const typeRef = findTypeAliasReference(sourceFile, "Result");
 
-      expect(typeRef).not.to.equal(null);
       const result = expandConditionalUtilityType(
-        typeRef!,
+        assertDefined(typeRef, "typeRef should be defined"),
         "ReturnType",
         checker,
         stubConvertType
@@ -1121,9 +1100,8 @@ describe("Conditional Utility Type Expansion", () => {
       const { checker, sourceFile } = createTestProgram(source);
       const typeRef = findTypeAliasReference(sourceFile, "Result");
 
-      expect(typeRef).not.to.equal(null);
       const result = expandConditionalUtilityType(
-        typeRef!,
+        assertDefined(typeRef, "typeRef should be defined"),
         "ReturnType",
         checker,
         stubConvertType
@@ -1143,9 +1121,8 @@ describe("Conditional Utility Type Expansion", () => {
       const { checker, sourceFile } = createTestProgram(source);
       const typeRef = findTypeAliasReference(sourceFile, "Result");
 
-      expect(typeRef).not.to.equal(null);
       const result = expandConditionalUtilityType(
-        typeRef!,
+        assertDefined(typeRef, "typeRef should be defined"),
         "ReturnType",
         checker,
         stubConvertType
@@ -1178,9 +1155,8 @@ describe("Conditional Utility Type Expansion", () => {
       };
       ts.forEachChild(sourceFile, visitor);
 
-      expect(typeRef).not.to.equal(null);
       const result = expandConditionalUtilityType(
-        typeRef!,
+        assertDefined(typeRef, "typeRef should be defined"),
         "ReturnType",
         checker,
         stubConvertType
@@ -1200,9 +1176,8 @@ describe("Conditional Utility Type Expansion", () => {
       const { checker, sourceFile } = createTestProgram(source);
       const typeRef = findTypeAliasReference(sourceFile, "Result");
 
-      expect(typeRef).not.to.equal(null);
       const result = expandConditionalUtilityType(
-        typeRef!,
+        assertDefined(typeRef, "typeRef should be defined"),
         "ReturnType",
         checker,
         stubConvertType
@@ -1225,9 +1200,8 @@ describe("Conditional Utility Type Expansion", () => {
       const { checker, sourceFile } = createTestProgram(source);
       const typeRef = findTypeAliasReference(sourceFile, "Result");
 
-      expect(typeRef).not.to.equal(null);
       const result = expandConditionalUtilityType(
-        typeRef!,
+        assertDefined(typeRef, "typeRef should be defined"),
         "Parameters",
         checker,
         stubConvertType
@@ -1245,12 +1219,11 @@ describe("Conditional Utility Type Expansion", () => {
       const { checker, sourceFile } = createTestProgram(source);
       const typeRef = findTypeAliasReference(sourceFile, "Result");
 
-      expect(typeRef).not.to.equal(null);
       // Empty tuple may return null (falls through to referenceType)
       // or may return an expanded type - both are acceptable behaviors
       // The key is that it doesn't throw an error
       expandConditionalUtilityType(
-        typeRef!,
+        assertDefined(typeRef, "typeRef should be defined"),
         "Parameters",
         checker,
         stubConvertType
@@ -1265,9 +1238,8 @@ describe("Conditional Utility Type Expansion", () => {
       const { checker, sourceFile } = createTestProgram(source);
       const typeRef = findTypeAliasReference(sourceFile, "Result");
 
-      expect(typeRef).not.to.equal(null);
       const result = expandConditionalUtilityType(
-        typeRef!,
+        assertDefined(typeRef, "typeRef should be defined"),
         "Parameters",
         checker,
         stubConvertType
@@ -1301,9 +1273,8 @@ describe("Conditional Utility Type Expansion", () => {
       };
       ts.forEachChild(sourceFile, visitor);
 
-      expect(typeRef).not.to.equal(null);
       const result = expandConditionalUtilityType(
-        typeRef!,
+        assertDefined(typeRef, "typeRef should be defined"),
         "Parameters",
         checker,
         stubConvertType
@@ -1321,9 +1292,8 @@ describe("Conditional Utility Type Expansion", () => {
       const { checker, sourceFile } = createTestProgram(source);
       const typeRef = findTypeAliasReference(sourceFile, "Result");
 
-      expect(typeRef).not.to.equal(null);
       const result = expandConditionalUtilityType(
-        typeRef!,
+        assertDefined(typeRef, "typeRef should be defined"),
         "Parameters",
         checker,
         stubConvertType
@@ -1342,9 +1312,8 @@ describe("Conditional Utility Type Expansion", () => {
       const { checker, sourceFile } = createTestProgram(source);
       const typeRef = findTypeAliasReference(sourceFile, "Result");
 
-      expect(typeRef).not.to.equal(null);
       const result = expandConditionalUtilityType(
-        typeRef!,
+        assertDefined(typeRef, "typeRef should be defined"),
         "Awaited",
         checker,
         stubConvertType
@@ -1365,9 +1334,8 @@ describe("Conditional Utility Type Expansion", () => {
       const { checker, sourceFile } = createTestProgram(source);
       const typeRef = findTypeAliasReference(sourceFile, "Result");
 
-      expect(typeRef).not.to.equal(null);
       const result = expandConditionalUtilityType(
-        typeRef!,
+        assertDefined(typeRef, "typeRef should be defined"),
         "Awaited",
         checker,
         stubConvertType
@@ -1388,9 +1356,8 @@ describe("Conditional Utility Type Expansion", () => {
       const { checker, sourceFile } = createTestProgram(source);
       const typeRef = findTypeAliasReference(sourceFile, "Result");
 
-      expect(typeRef).not.to.equal(null);
       const result = expandConditionalUtilityType(
-        typeRef!,
+        assertDefined(typeRef, "typeRef should be defined"),
         "Awaited",
         checker,
         stubConvertType
@@ -1411,9 +1378,8 @@ describe("Conditional Utility Type Expansion", () => {
       const { checker, sourceFile } = createTestProgram(source);
       const typeRef = findTypeAliasReference(sourceFile, "Result");
 
-      expect(typeRef).not.to.equal(null);
       const result = expandConditionalUtilityType(
-        typeRef!,
+        assertDefined(typeRef, "typeRef should be defined"),
         "Awaited",
         checker,
         stubConvertType
@@ -1446,9 +1412,8 @@ describe("Conditional Utility Type Expansion", () => {
       };
       ts.forEachChild(sourceFile, visitor);
 
-      expect(typeRef).not.to.equal(null);
       const result = expandConditionalUtilityType(
-        typeRef!,
+        assertDefined(typeRef, "typeRef should be defined"),
         "Awaited",
         checker,
         stubConvertType
@@ -1465,9 +1430,8 @@ describe("Conditional Utility Type Expansion", () => {
       const { checker, sourceFile } = createTestProgram(source);
       const typeRef = findTypeAliasReference(sourceFile, "Result");
 
-      expect(typeRef).not.to.equal(null);
       const result = expandConditionalUtilityType(
-        typeRef!,
+        assertDefined(typeRef, "typeRef should be defined"),
         "Awaited",
         checker,
         stubConvertType
@@ -1492,8 +1456,11 @@ describe("Record Type Expansion", () => {
       const { checker, sourceFile } = createTestProgram(source);
       const typeRef = findTypeAliasReference(sourceFile, "Config");
 
-      expect(typeRef).not.to.equal(null);
-      const result = expandRecordType(typeRef!, checker, stubConvertType);
+      const result = expandRecordType(
+        assertDefined(typeRef, "typeRef should be defined"),
+        checker,
+        stubConvertType
+      );
 
       expect(result).not.to.equal(null);
       expect(result?.kind).to.equal("objectType");
@@ -1514,8 +1481,11 @@ describe("Record Type Expansion", () => {
       const { checker, sourceFile } = createTestProgram(source);
       const typeRef = findTypeAliasReference(sourceFile, "IndexedConfig");
 
-      expect(typeRef).not.to.equal(null);
-      const result = expandRecordType(typeRef!, checker, stubConvertType);
+      const result = expandRecordType(
+        assertDefined(typeRef, "typeRef should be defined"),
+        checker,
+        stubConvertType
+      );
 
       expect(result).not.to.equal(null);
       expect(result?.kind).to.equal("objectType");
@@ -1537,8 +1507,11 @@ describe("Record Type Expansion", () => {
       const { checker, sourceFile } = createTestProgram(source);
       const typeRef = findTypeAliasReference(sourceFile, "MixedConfig");
 
-      expect(typeRef).not.to.equal(null);
-      const result = expandRecordType(typeRef!, checker, stubConvertType);
+      const result = expandRecordType(
+        assertDefined(typeRef, "typeRef should be defined"),
+        checker,
+        stubConvertType
+      );
 
       expect(result).not.to.equal(null);
       expect(result?.kind).to.equal("objectType");
@@ -1555,8 +1528,11 @@ describe("Record Type Expansion", () => {
       const { checker, sourceFile } = createTestProgram(source);
       const typeRef = findTypeAliasReference(sourceFile, "Dictionary");
 
-      expect(typeRef).not.to.equal(null);
-      const result = expandRecordType(typeRef!, checker, stubConvertType);
+      const result = expandRecordType(
+        assertDefined(typeRef, "typeRef should be defined"),
+        checker,
+        stubConvertType
+      );
 
       // Should return null - use IrDictionaryType instead
       expect(result).to.equal(null);
@@ -1570,8 +1546,11 @@ describe("Record Type Expansion", () => {
       const { checker, sourceFile } = createTestProgram(source);
       const typeRef = findTypeAliasReference(sourceFile, "NumberDictionary");
 
-      expect(typeRef).not.to.equal(null);
-      const result = expandRecordType(typeRef!, checker, stubConvertType);
+      const result = expandRecordType(
+        assertDefined(typeRef, "typeRef should be defined"),
+        checker,
+        stubConvertType
+      );
 
       // Should return null - use IrDictionaryType instead
       expect(result).to.equal(null);
@@ -1600,8 +1579,11 @@ describe("Record Type Expansion", () => {
       };
       ts.forEachChild(sourceFile, visitor);
 
-      expect(typeRef).not.to.equal(null);
-      const result = expandRecordType(typeRef!, checker, stubConvertType);
+      const result = expandRecordType(
+        assertDefined(typeRef, "typeRef should be defined"),
+        checker,
+        stubConvertType
+      );
 
       // Should return null - type parameter can't be expanded
       expect(result).to.equal(null);
@@ -1617,8 +1599,11 @@ describe("Record Type Expansion", () => {
       const { checker, sourceFile } = createTestProgram(source);
       const typeRef = findTypeAliasReference(sourceFile, "AnyKeyRecord");
 
-      expect(typeRef).not.to.equal(null);
-      const result = expandRecordType(typeRef!, checker, stubConvertType);
+      const result = expandRecordType(
+        assertDefined(typeRef, "typeRef should be defined"),
+        checker,
+        stubConvertType
+      );
 
       // Should return null - PropertyKey is not a finite set of literals
       // and should fall through to referenceType (not dictionaryType)
@@ -1653,13 +1638,17 @@ describe("Record Type Expansion", () => {
       };
       ts.forEachChild(sourceFile, visitor);
 
-      expect(typeRef).not.to.equal(null);
-
       // Get the key type node and check its flags
-      const keyTypeNode = typeRef!.typeArguments?.[0];
-      expect(keyTypeNode).not.to.equal(undefined);
+      const definedTypeRef = assertDefined(
+        typeRef,
+        "typeRef should be defined"
+      );
+      const keyTypeNode = assertDefined(
+        definedTypeRef.typeArguments?.[0],
+        "keyTypeNode should be defined"
+      );
 
-      const keyTsType = checker.getTypeAtLocation(keyTypeNode!);
+      const keyTsType = checker.getTypeAtLocation(keyTypeNode);
 
       // The key type should be a type parameter, not string
       expect(!!(keyTsType.flags & ts.TypeFlags.TypeParameter)).to.equal(true);

--- a/packages/frontend/src/ir/validation/anonymous-type-lowering-pass.ts
+++ b/packages/frontend/src/ir/validation/anonymous-type-lowering-pass.ts
@@ -292,9 +292,11 @@ const lowerType = (type: IrType, ctx: LoweringContext): IrType => {
 
     case "referenceType": {
       // Lower both typeArguments and structuralMembers
-      const hasTypeArgs = type.typeArguments && type.typeArguments.length > 0;
+      const typeArgs = type.typeArguments;
+      const structuralMembers = type.structuralMembers;
+      const hasTypeArgs = typeArgs !== undefined && typeArgs.length > 0;
       const hasStructuralMembers =
-        type.structuralMembers && type.structuralMembers.length > 0;
+        structuralMembers !== undefined && structuralMembers.length > 0;
 
       if (!hasTypeArgs && !hasStructuralMembers) {
         return type;
@@ -303,10 +305,10 @@ const lowerType = (type: IrType, ctx: LoweringContext): IrType => {
       return {
         ...type,
         typeArguments: hasTypeArgs
-          ? type.typeArguments!.map((ta) => lowerType(ta, ctx))
+          ? typeArgs.map((ta) => lowerType(ta, ctx))
           : undefined,
         structuralMembers: hasStructuralMembers
-          ? type.structuralMembers!.map((m) => lowerInterfaceMember(m, ctx))
+          ? structuralMembers.map((m) => lowerInterfaceMember(m, ctx))
           : undefined,
       };
     }

--- a/packages/frontend/src/ir/validation/attribute-collection-pass.test.ts
+++ b/packages/frontend/src/ir/validation/attribute-collection-pass.test.ts
@@ -10,6 +10,16 @@ import type {
   IrFunctionDeclaration,
 } from "../types.js";
 
+/**
+ * Assert value is not null/undefined and return it typed as non-null.
+ */
+const assertDefined = <T>(value: T | null | undefined, msg?: string): T => {
+  if (value === null || value === undefined) {
+    throw new Error(msg ?? "Expected value to be defined");
+  }
+  return value;
+};
+
 describe("Attribute Collection Pass", () => {
   /**
    * Helper to create a minimal IrModule for testing
@@ -100,16 +110,15 @@ describe("Attribute Collection Pass", () => {
       expect(result.ok).to.be.true;
       expect(result.modules).to.have.length(1);
 
-      const processedModule = result.modules[0]!;
+      const processedModule = assertDefined(result.modules[0]);
       // Marker statement should be removed
       expect(processedModule.body).to.have.length(1);
 
       const classDecl = processedModule.body[0] as IrClassDeclaration;
       expect(classDecl.kind).to.equal("classDeclaration");
       expect(classDecl.attributes).to.have.length(1);
-      expect(classDecl.attributes![0]!.attributeType.kind).to.equal(
-        "referenceType"
-      );
+      const attr0 = assertDefined(classDecl.attributes?.[0]);
+      expect(attr0.attributeType.kind).to.equal("referenceType");
     });
 
     it("should attach attribute with positional arguments", () => {
@@ -134,10 +143,12 @@ describe("Attribute Collection Pass", () => {
 
       expect(result.ok).to.be.true;
 
-      const classDecl = result.modules[0]!.body[0] as IrClassDeclaration;
+      const mod = assertDefined(result.modules[0]);
+      const classDecl = mod.body[0] as IrClassDeclaration;
       expect(classDecl.attributes).to.have.length(1);
-      expect(classDecl.attributes![0]!.positionalArgs).to.have.length(1);
-      expect(classDecl.attributes![0]!.positionalArgs[0]).to.deep.equal({
+      const attr = assertDefined(classDecl.attributes?.[0]);
+      expect(attr.positionalArgs).to.have.length(1);
+      expect(attr.positionalArgs[0]).to.deep.equal({
         kind: "string",
         value: "Use NewUser instead",
       });
@@ -165,9 +176,10 @@ describe("Attribute Collection Pass", () => {
       const result = runAttributeCollectionPass([module]);
 
       expect(result.ok).to.be.true;
-      expect(result.modules[0]!.body).to.have.length(1);
+      const mod = assertDefined(result.modules[0]);
+      expect(mod.body).to.have.length(1);
 
-      const funcDecl = result.modules[0]!.body[0] as IrFunctionDeclaration;
+      const funcDecl = mod.body[0] as IrFunctionDeclaration;
       expect(funcDecl.kind).to.equal("functionDeclaration");
       expect(funcDecl.attributes).to.have.length(1);
     });
@@ -185,7 +197,8 @@ describe("Attribute Collection Pass", () => {
 
       expect(result.ok).to.be.true; // Diagnostics are warnings, not hard failures
       expect(result.diagnostics).to.have.length(1);
-      expect(result.diagnostics[0]!.message).to.include("NotExist");
+      const diag = assertDefined(result.diagnostics[0]);
+      expect(diag.message).to.include("NotExist");
     });
   });
 
@@ -233,9 +246,10 @@ describe("Attribute Collection Pass", () => {
       const result = runAttributeCollectionPass([module]);
 
       expect(result.ok).to.be.true;
-      expect(result.modules[0]!.body).to.have.length(1);
+      const mod = assertDefined(result.modules[0]);
+      expect(mod.body).to.have.length(1);
 
-      const classDecl = result.modules[0]!.body[0] as IrClassDeclaration;
+      const classDecl = mod.body[0] as IrClassDeclaration;
       expect(classDecl.attributes).to.have.length(2);
     });
   });

--- a/packages/frontend/src/ir/validation/yield-lowering-pass.test.ts
+++ b/packages/frontend/src/ir/validation/yield-lowering-pass.test.ts
@@ -21,6 +21,16 @@ import {
 } from "../types.js";
 
 /**
+ * Assert value is not null/undefined and return it typed as non-null.
+ */
+const assertDefined = <T>(value: T | null | undefined, msg?: string): T => {
+  if (value === null || value === undefined) {
+    throw new Error(msg ?? "Expected value to be defined");
+  }
+  return value;
+};
+
+/**
  * Helper to create a minimal generator function module
  */
 const createGeneratorModule = (
@@ -96,7 +106,7 @@ describe("Yield Lowering Pass", () => {
       expect(result.ok).to.be.true;
       expect(result.diagnostics).to.have.length(0);
 
-      const body = getGeneratorBody(result.modules[0]!);
+      const body = getGeneratorBody(assertDefined(result.modules[0]));
       expect(body).to.have.length(1);
       expect(body[0]?.kind).to.equal("yieldStatement");
 
@@ -117,7 +127,7 @@ describe("Yield Lowering Pass", () => {
       const result = runYieldLoweringPass([module]);
 
       expect(result.ok).to.be.true;
-      const body = getGeneratorBody(result.modules[0]!);
+      const body = getGeneratorBody(assertDefined(result.modules[0]));
       const yieldStmt = body[0] as IrYieldStatement;
       expect(yieldStmt.kind).to.equal("yieldStatement");
       expect(yieldStmt.output).to.be.undefined;
@@ -137,7 +147,7 @@ describe("Yield Lowering Pass", () => {
       const result = runYieldLoweringPass([module]);
 
       expect(result.ok).to.be.true;
-      const body = getGeneratorBody(result.modules[0]!);
+      const body = getGeneratorBody(assertDefined(result.modules[0]));
       const yieldStmt = body[0] as IrYieldStatement;
       expect(yieldStmt.delegate).to.be.true;
       expect(yieldStmt.output?.kind).to.equal("identifier");
@@ -165,7 +175,7 @@ describe("Yield Lowering Pass", () => {
       const result = runYieldLoweringPass([module]);
 
       expect(result.ok).to.be.true;
-      const body = getGeneratorBody(result.modules[0]!);
+      const body = getGeneratorBody(assertDefined(result.modules[0]));
       expect(body).to.have.length(1);
 
       const yieldStmt = body[0] as IrYieldStatement;
@@ -203,7 +213,7 @@ describe("Yield Lowering Pass", () => {
       const result = runYieldLoweringPass([module]);
 
       expect(result.ok).to.be.true;
-      const body = getGeneratorBody(result.modules[0]!);
+      const body = getGeneratorBody(assertDefined(result.modules[0]));
       // Should produce two yieldStatements
       expect(body).to.have.length(2);
       expect(body[0]?.kind).to.equal("yieldStatement");
@@ -228,7 +238,7 @@ describe("Yield Lowering Pass", () => {
       const result = runYieldLoweringPass([module]);
 
       expect(result.ok).to.be.true;
-      const body = getGeneratorBody(result.modules[0]!);
+      const body = getGeneratorBody(assertDefined(result.modules[0]));
       const yieldStmt = body[0] as IrYieldStatement;
       expect(yieldStmt.kind).to.equal("yieldStatement");
       expect(yieldStmt.receiveTarget?.kind).to.equal("identifierPattern");
@@ -282,7 +292,7 @@ describe("Yield Lowering Pass", () => {
       const result = runYieldLoweringPass([module]);
 
       expect(result.ok).to.be.true;
-      const body = getGeneratorBody(result.modules[0]!);
+      const body = getGeneratorBody(assertDefined(result.modules[0]));
       const yieldStmt = body[0] as IrYieldStatement;
       expect(yieldStmt.receiveTarget?.kind).to.equal("arrayPattern");
     });
@@ -316,7 +326,7 @@ describe("Yield Lowering Pass", () => {
       const result = runYieldLoweringPass([module]);
 
       expect(result.ok).to.be.true;
-      const body = getGeneratorBody(result.modules[0]!);
+      const body = getGeneratorBody(assertDefined(result.modules[0]));
       const yieldStmt = body[0] as IrYieldStatement;
       expect(yieldStmt.receiveTarget?.kind).to.equal("objectPattern");
     });
@@ -451,7 +461,7 @@ describe("Yield Lowering Pass", () => {
       const result = runYieldLoweringPass([module]);
 
       expect(result.ok).to.be.true;
-      const body = getGeneratorBody(result.modules[0]!);
+      const body = getGeneratorBody(assertDefined(result.modules[0]));
       const ifStmt = body[0] as Extract<IrStatement, { kind: "ifStatement" }>;
       const thenBlock = ifStmt.thenStatement as IrBlockStatement;
       expect(thenBlock.statements[0]?.kind).to.equal("yieldStatement");
@@ -544,7 +554,7 @@ describe("Yield Lowering Pass", () => {
 
       // The pass doesn't transform non-generators
       expect(result.ok).to.be.true;
-      const body = getGeneratorBody(result.modules[0]!);
+      const body = getGeneratorBody(assertDefined(result.modules[0]));
       // Should still be expressionStatement with yield, not yieldStatement
       expect(body[0]?.kind).to.equal("expressionStatement");
     });
@@ -634,8 +644,8 @@ describe("Yield Lowering Pass", () => {
       expect(result.ok).to.be.true;
       expect(result.modules).to.have.length(2);
 
-      const body1 = getGeneratorBody(result.modules[0]!);
-      const body2 = getGeneratorBody(result.modules[1]!);
+      const body1 = getGeneratorBody(assertDefined(result.modules[0]));
+      const body2 = getGeneratorBody(assertDefined(result.modules[1]));
 
       expect(body1[0]?.kind).to.equal("yieldStatement");
       expect(body2[0]?.kind).to.equal("yieldStatement");


### PR DESCRIPTION
Replace forbidden `!` non-null assertions with explicit null checks using assertDefined() helper functions. This improves type safety by making the null checks explicit and throwing descriptive errors when values are unexpectedly null/undefined.

Files fixed:
- utility-types.test.ts (60 errors)
- anonymous-type-lowering-pass.ts (2 errors)
- attribute-collection-pass.test.ts (15 errors)
- yield-lowering-pass.test.ts (12 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)