### PR TITLE
fix: Emit .Length (capital L) for arrays and strings in dotnet mode

### DIFF
--- a/packages/emitter/src/expressions/access.ts
+++ b/packages/emitter/src/expressions/access.ts
@@ -256,10 +256,16 @@ export const emitMemberAccess = (
   }
 
   // In JS runtime mode, rewrite array.length → global::Tsonic.JSRuntime.Array.length(array)
-  // In dotnet mode, there is no JS emulation - users access .Count directly on List<T>
-  if (isArrayType && prop === "length" && runtime === "js") {
-    const text = `global::Tsonic.JSRuntime.Array.length(${objectFrag.text})`;
-    return [{ text }, newContext];
+  // In dotnet mode, C# arrays use .Length (capital L)
+  if (isArrayType && prop === "length") {
+    if (runtime === "js") {
+      const text = `global::Tsonic.JSRuntime.Array.length(${objectFrag.text})`;
+      return [{ text }, newContext];
+    } else {
+      // dotnet mode: C# arrays have .Length property
+      const text = `${objectFrag.text}.Length`;
+      return [{ text }, newContext];
+    }
   }
 
   // Check if this is a string type
@@ -267,10 +273,16 @@ export const emitMemberAccess = (
     objectType?.kind === "primitiveType" && objectType.name === "string";
 
   // In JS runtime mode, rewrite string.length → global::Tsonic.JSRuntime.String.length(string)
-  // In dotnet mode, use C#'s native .Length property
-  if (isStringType && prop === "length" && runtime === "js") {
-    const text = `global::Tsonic.JSRuntime.String.length(${objectFrag.text})`;
-    return [{ text }, newContext];
+  // In dotnet mode, C# strings use .Length (capital L)
+  if (isStringType && prop === "length") {
+    if (runtime === "js") {
+      const text = `global::Tsonic.JSRuntime.String.length(${objectFrag.text})`;
+      return [{ text }, newContext];
+    } else {
+      // dotnet mode: C# strings have .Length property
+      const text = `${objectFrag.text}.Length`;
+      return [{ text }, newContext];
+    }
   }
 
   // Handle explicit interface view properties (As_IInterface)

--- a/packages/frontend/src/ir/type-converter/utility-types.test.ts
+++ b/packages/frontend/src/ir/type-converter/utility-types.test.ts
@@ -21,12 +21,12 @@ import { IrType } from "../types.js";
  * Assert value is not null/undefined and return it typed as non-null.
  * Throws if value is null or undefined.
  */
-const assertDefined = <T>(value: T | null | undefined, msg?: string): T => {
+function assertDefined<T>(value: T, msg?: string): NonNullable<T> {
   if (value === null || value === undefined) {
     throw new Error(msg ?? "Expected value to be defined");
   }
-  return value;
-};
+  return value as NonNullable<T>;
+}
 
 /**
  * Helper to create a TypeScript program from source code
@@ -1639,16 +1639,13 @@ describe("Record Type Expansion", () => {
       ts.forEachChild(sourceFile, visitor);
 
       // Get the key type node and check its flags
-      const definedTypeRef = assertDefined(
-        typeRef,
-        "typeRef should be defined"
-      );
-      const keyTypeNode = assertDefined(
-        definedTypeRef.typeArguments?.[0],
-        "keyTypeNode should be defined"
-      );
-
-      const keyTsType = checker.getTypeAtLocation(keyTypeNode);
+      expect(typeRef).not.to.equal(null);
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      const foundTypeRef = typeRef!;
+      const keyTypeNode = foundTypeRef.typeArguments?.[0];
+      expect(keyTypeNode).not.to.equal(undefined);
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      const keyTsType = checker.getTypeAtLocation(keyTypeNode!);
 
       // The key type should be a type parameter, not string
       expect(!!(keyTsType.flags & ts.TypeFlags.TypeParameter)).to.equal(true);


### PR DESCRIPTION
In dotnet mode, C# arrays and strings use .Length property (capital L), not .length (lowercase). This fix ensures:

- Array<T>.length → arr.Length
- ReadonlyArray<T>.length → arr.Length
- string.length → str.Length

The JS runtime mode continues to use Tsonic.JSRuntime helper functions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)