### PR TITLE
feat: Emit C# casts for type assertions

### DIFF
--- a/packages/emitter/testcases/common/dotnet/types/type-assertions/TypeAssertions.cs
+++ b/packages/emitter/testcases/common/dotnet/types/type-assertions/TypeAssertions.cs
@@ -1,0 +1,42 @@
+namespace TestCases.common.types.typeassertions
+{
+    internal class Animal
+    {
+        public string name;
+    }
+    internal class Dog : Animal
+    {
+        public string breed;
+    }
+
+            public static class TypeAssertions
+            {
+                public static readonly int intFromLiteral = 1000;
+
+                public static readonly byte byteFromLiteral = 255;
+
+                public static readonly short shortFromLiteral = 1000;
+
+                public static readonly long longFromLiteral = 1000000;
+
+                public static readonly float floatFromLiteral = 1.5;
+
+                public static readonly double doubleFromLiteral = 1.5;
+
+                public static readonly object someObject = new Dog();
+
+                public static readonly Animal asAnimal = (Animal)someObject;
+
+                public static Animal testReferenceCasts(object obj)
+                    {
+                    var animal = (Animal)obj;
+                    return animal;
+                    }
+
+                public static Dog testDownCast(Animal animal)
+                    {
+                    var dog = (Dog)animal;
+                    return dog;
+                    }
+            }
+}

--- a/packages/emitter/testcases/common/dotnet/types/variable-decls/VariableDecls.cs
+++ b/packages/emitter/testcases/common/dotnet/types/variable-decls/VariableDecls.cs
@@ -1,0 +1,62 @@
+namespace TestCases.common.types.variabledecls
+{
+        public static class VariableDecls
+        {
+            public static readonly double inferredDouble = 42.5;
+
+            public static readonly double inferredInt = 42;
+
+            public static readonly string inferredString = "hello";
+
+            public static readonly bool inferredBool = true;
+
+            public static readonly int explicitInt = 42;
+
+            public static readonly byte explicitByte = 255;
+
+            public static readonly short explicitShort = 1000;
+
+            public static readonly long explicitLong = 1000000;
+
+            public static readonly float explicitFloat = 1.5;
+
+            public static readonly double explicitDouble = 1.5;
+
+            public static readonly string explicitString = "world";
+
+            public static readonly bool explicitBool = false;
+
+            public static readonly int assertedInt = 42;
+
+            public static readonly byte assertedByte = 255;
+
+            public static readonly short assertedShort = 1000;
+
+            public static readonly long assertedLong = 1000000;
+
+            public static readonly float assertedFloat = 1.5;
+
+            public static readonly double assertedDouble = 42;
+
+            public static void localDeclarations()
+                {
+                var localInferredDouble = 42.5;
+                var localInferredInt = 42;
+                var localInferredString = "local";
+                var localInferredBool = true;
+                int localExplicitInt = 100;
+                byte localExplicitByte = 200;
+                float localExplicitFloat = 3.14;
+                string localExplicitString = "explicit";
+                var localAssertedInt = 200;
+                var localAssertedFloat = 3.14;
+                var localAssertedDouble = 100;
+                }
+
+            public static int mutableInt = 0;
+
+            public static string mutableString = "";
+
+            public static readonly int immutableInt = 42;
+        }
+}

--- a/packages/emitter/testcases/common/js/types/type-assertions/TypeAssertions.cs
+++ b/packages/emitter/testcases/common/js/types/type-assertions/TypeAssertions.cs
@@ -1,0 +1,42 @@
+namespace TestCases.common.types.typeassertions
+{
+    internal class Animal
+    {
+        public string name;
+    }
+    internal class Dog : Animal
+    {
+        public string breed;
+    }
+
+            public static class TypeAssertions
+            {
+                public static readonly int intFromLiteral = 1000;
+
+                public static readonly byte byteFromLiteral = 255;
+
+                public static readonly short shortFromLiteral = 1000;
+
+                public static readonly long longFromLiteral = 1000000;
+
+                public static readonly float floatFromLiteral = 1.5;
+
+                public static readonly double doubleFromLiteral = 1.5;
+
+                public static readonly object someObject = new Dog();
+
+                public static readonly Animal asAnimal = (Animal)someObject;
+
+                public static Animal testReferenceCasts(object obj)
+                    {
+                    var animal = (Animal)obj;
+                    return animal;
+                    }
+
+                public static Dog testDownCast(Animal animal)
+                    {
+                    var dog = (Dog)animal;
+                    return dog;
+                    }
+            }
+}

--- a/packages/emitter/testcases/common/js/types/variable-decls/VariableDecls.cs
+++ b/packages/emitter/testcases/common/js/types/variable-decls/VariableDecls.cs
@@ -1,0 +1,62 @@
+namespace TestCases.common.types.variabledecls
+{
+        public static class VariableDecls
+        {
+            public static readonly double inferredDouble = 42.5;
+
+            public static readonly double inferredInt = 42;
+
+            public static readonly string inferredString = "hello";
+
+            public static readonly bool inferredBool = true;
+
+            public static readonly int explicitInt = 42;
+
+            public static readonly byte explicitByte = 255;
+
+            public static readonly short explicitShort = 1000;
+
+            public static readonly long explicitLong = 1000000;
+
+            public static readonly float explicitFloat = 1.5;
+
+            public static readonly double explicitDouble = 1.5;
+
+            public static readonly string explicitString = "world";
+
+            public static readonly bool explicitBool = false;
+
+            public static readonly int assertedInt = 42;
+
+            public static readonly byte assertedByte = 255;
+
+            public static readonly short assertedShort = 1000;
+
+            public static readonly long assertedLong = 1000000;
+
+            public static readonly float assertedFloat = 1.5;
+
+            public static readonly double assertedDouble = 42;
+
+            public static void localDeclarations()
+                {
+                var localInferredDouble = 42.5;
+                var localInferredInt = 42;
+                var localInferredString = "local";
+                var localInferredBool = true;
+                int localExplicitInt = 100;
+                byte localExplicitByte = 200;
+                float localExplicitFloat = 3.14;
+                string localExplicitString = "explicit";
+                var localAssertedInt = 200;
+                var localAssertedFloat = 3.14;
+                var localAssertedDouble = 100;
+                }
+
+            public static int mutableInt = 0;
+
+            public static string mutableString = "";
+
+            public static readonly int immutableInt = 42;
+        }
+}

--- a/packages/emitter/testcases/common/types/type-assertions/TypeAssertions.ts
+++ b/packages/emitter/testcases/common/types/type-assertions/TypeAssertions.ts
@@ -1,0 +1,42 @@
+import { int, byte, short, long, float } from "@tsonic/core/types.js";
+
+// =============================================================================
+// Module-level numeric assertions (Bug 1: should emit correct CLR type)
+// =============================================================================
+
+export const intFromLiteral = 1000 as int;
+export const byteFromLiteral = 255 as byte;
+export const shortFromLiteral = 1000 as short;
+export const longFromLiteral = 1000000 as long;
+export const floatFromLiteral = 1.5 as float;
+export const doubleFromLiteral = 1.5 as number;
+
+// =============================================================================
+// Reference type assertions (Bug 2: should emit C# cast)
+// =============================================================================
+
+class Animal {
+  name!: string;
+}
+
+class Dog extends Animal {
+  breed!: string;
+}
+
+// Module-level reference type cast
+export const someObject: object = new Dog();
+export const asAnimal = someObject as Animal;
+
+// =============================================================================
+// Function with reference type casts
+// =============================================================================
+
+export function testReferenceCasts(obj: object): Animal {
+  const animal = obj as Animal;
+  return animal;
+}
+
+export function testDownCast(animal: Animal): Dog {
+  const dog = animal as Dog;
+  return dog;
+}

--- a/packages/emitter/testcases/common/types/type-assertions/config.yaml
+++ b/packages/emitter/testcases/common/types/type-assertions/config.yaml
@@ -1,0 +1,1 @@
+- TypeAssertions.ts: should emit C# casts for type assertions

--- a/packages/emitter/testcases/common/types/variable-decls/VariableDecls.ts
+++ b/packages/emitter/testcases/common/types/variable-decls/VariableDecls.ts
@@ -1,0 +1,65 @@
+import { int, byte, short, long, float } from "@tsonic/core/types.js";
+
+// =============================================================================
+// Section 1: Inferred types (module level)
+// =============================================================================
+
+export const inferredDouble = 42.5;
+export const inferredInt = 42; // Lexeme is integer, but TS sees as number
+export const inferredString = "hello";
+export const inferredBool = true;
+
+// =============================================================================
+// Section 2: Explicit type annotations (module level)
+// =============================================================================
+
+export const explicitInt: int = 42;
+export const explicitByte: byte = 255;
+export const explicitShort: short = 1000;
+export const explicitLong: long = 1000000;
+export const explicitFloat: float = 1.5;
+export const explicitDouble: number = 1.5;
+export const explicitString: string = "world";
+export const explicitBool: boolean = false;
+
+// =============================================================================
+// Section 3: Type assertions on literals (module level)
+// =============================================================================
+
+export const assertedInt = 42 as int;
+export const assertedByte = 255 as byte;
+export const assertedShort = 1000 as short;
+export const assertedLong = 1000000 as long;
+export const assertedFloat = 1.5 as float;
+export const assertedDouble = 42 as number;
+
+// =============================================================================
+// Section 4: Local declarations (inside function scope)
+// =============================================================================
+
+export function localDeclarations(): void {
+  // Inferred types (C# uses var)
+  const localInferredDouble = 42.5;
+  const localInferredInt = 42;
+  const localInferredString = "local";
+  const localInferredBool = true;
+
+  // Explicit annotations
+  const localExplicitInt: int = 100;
+  const localExplicitByte: byte = 200;
+  const localExplicitFloat: float = 3.14;
+  const localExplicitString: string = "explicit";
+
+  // Type assertions
+  const localAssertedInt = 200 as int;
+  const localAssertedFloat = 3.14 as float;
+  const localAssertedDouble = 100 as number;
+}
+
+// =============================================================================
+// Section 5: Mutable variables (let vs const)
+// =============================================================================
+
+export let mutableInt: int = 0;
+export let mutableString: string = "";
+export const immutableInt: int = 42;

--- a/packages/emitter/testcases/common/types/variable-decls/config.yaml
+++ b/packages/emitter/testcases/common/types/variable-decls/config.yaml
@@ -1,0 +1,1 @@
+- VariableDecls.ts: should emit correct C# types for variable declarations

--- a/packages/frontend/src/ir/types.ts
+++ b/packages/frontend/src/ir/types.ts
@@ -65,6 +65,8 @@ export type {
   IrAwaitExpression,
   IrYieldExpression,
   IrNumericNarrowingExpression,
+  IrTypeAssertionExpression,
+  IrTryCastExpression,
   NumericProof,
   ProofSource,
   ComputedAccessKind,

--- a/packages/frontend/src/ir/types/index.ts
+++ b/packages/frontend/src/ir/types/index.ts
@@ -70,6 +70,8 @@ export type {
   IrAwaitExpression,
   IrYieldExpression,
   IrNumericNarrowingExpression,
+  IrTypeAssertionExpression,
+  IrTryCastExpression,
   NumericProof,
   ProofSource,
   ComputedAccessKind,

--- a/packages/frontend/src/ir/validation/anonymous-type-lowering-pass.ts
+++ b/packages/frontend/src/ir/validation/anonymous-type-lowering-pass.ts
@@ -645,6 +645,22 @@ const lowerExpression = (
         expression: lowerExpression(expr.expression, ctx),
         inferredType: lowerType(expr.inferredType, ctx),
       };
+
+    case "typeAssertion":
+      return {
+        ...expr,
+        expression: lowerExpression(expr.expression, ctx),
+        targetType: lowerType(expr.targetType, ctx),
+        inferredType: lowerType(expr.inferredType, ctx),
+      };
+
+    case "tryCast":
+      return {
+        ...expr,
+        expression: lowerExpression(expr.expression, ctx),
+        targetType: lowerType(expr.targetType, ctx),
+        inferredType: lowerType(expr.inferredType, ctx),
+      };
   }
 };
 

--- a/test/fixtures/utility-types/src/index.ts
+++ b/test/fixtures/utility-types/src/index.ts
@@ -48,7 +48,7 @@ export function main(): void {
 
   // ReturnType tests - use inline to avoid alias emission issue
   const addResult: ReturnType<typeof add> = add(10.0, 20.0);
-  Console.writeLine("ReturnType<add>: " + (addResult as unknown as string));
+  Console.writeLine("ReturnType<add>: " + addResult);
 
   const greetResult: ReturnType<typeof greet> = greet("World");
   Console.writeLine("ReturnType<greet>: " + greetResult);


### PR DESCRIPTION
- `x as SomeClass` now emits `(SomeClass)x` in C#
- `x as unknown` is stripped (type erasure, no runtime effect)
- `x as int` and other numeric types create numericNarrowing (existing)
- `x as out<T>` and parameter modifiers are stripped (handled elsewhere)

Add IrTypeAssertionExpression and IrTryCastExpression IR nodes. Add emitTypeAssertion for throwing casts ((T)x).
Add emitTryCast for safe casts (x as T) - requires @tsonic/core@0.5.0.

Fix variable declaration to prioritize numericNarrowing/typeAssertion initializers over general decl.type for correct CLR type emission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)