### PR TITLE
fix: Read CLI version from package.json instead of hardcoding

### DIFF
--- a/packages/cli/src/cli/constants.ts
+++ b/packages/cli/src/cli/constants.ts
@@ -2,4 +2,9 @@
  * CLI constants
  */
 
-export const VERSION = "0.0.10";
+import { createRequire } from "module";
+
+const require = createRequire(import.meta.url);
+const packageJson = require("../../package.json") as { version: string };
+
+export const VERSION = packageJson.version;


### PR DESCRIPTION
Previously VERSION was hardcoded as "0.0.10" in constants.ts, causing --version to show stale version. Now reads dynamically from package.json at runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)