### PR TITLE
feat: Unify Int32 proof check for array indexing across js/dotnet modes

### DIFF
--- a/packages/emitter/src/array.test.ts
+++ b/packages/emitter/src/array.test.ts
@@ -283,7 +283,12 @@ describe("Array Emission", () => {
                     elementType: { kind: "primitiveType", name: "number" },
                   },
                 },
-                property: { kind: "literal", value: 0 },
+                property: {
+                  kind: "literal",
+                  value: 0,
+                  // Int32 proof marker (set by numeric proof pass)
+                  inferredType: { kind: "primitiveType", name: "int" },
+                },
                 isComputed: true,
                 isOptional: false,
               },


### PR DESCRIPTION
Both js and dotnet modes now require proven Int32 indices for array access. Previously, js mode skipped the proof check while dotnet mode enforced it.

Changes:
- access.ts: Unified array index GET with hasInt32Proof() check
- operators.ts: Added hasInt32Proof() helper, unified array index SET
- array.test.ts: Fixed unit test to include Int32 proof marker

The only difference between modes is now the emitted code:
- js mode: Array.get()/Array.set() for JS semantics
- dotnet mode: Native CLR indexers arr[i]

🤖 Generated with [Claude Code](https://claude.com/claude-code)