### PR TITLE
docs: Update documentation for Dec 15-28 features

### DIFF
--- a/docs/architecture/frontend.md
+++ b/docs/architecture/frontend.md
@@ -156,6 +156,56 @@ Recovers numeric intent from declarations:
 // Proof: x has numeric kind 'int32'
 ```
 
+### Anonymous Type Lowering Pass
+
+`ir/validation/anonymous-type-lowering-pass.ts`:
+
+Transforms anonymous object type literals into synthesized nominal classes:
+
+- Scans function signatures, variables, and class members for inline `{ x: T }` types
+- Generates unique class names: `funcName_Return`, `funcName_paramName`
+- Replaces inline types with references to synthesized classes
+- Hoists synthesized classes to module level
+
+```typescript
+// Before: function getPoint(): { x: number; y: number }
+// After:  function getPoint(): getPoint_Return
+//         class getPoint_Return { x: number; y: number }
+```
+
+### Attribute Collection Pass
+
+`ir/validation/attribute-collection-pass.ts`:
+
+Collects C# attribute declarations from marker-call API:
+
+- Scans for `A.on(Class).type.add(AttrType, ...args)` patterns
+- Extracts attribute type and constructor arguments
+- Attaches attribute metadata to IR class declarations
+- Enables C# `[Attribute]` generation
+
+```typescript
+// Input:  A.on(User).type.add(SerializableAttribute)
+// Result: User class marked with [Serializable] in emitted C#
+```
+
+### Generic Validation
+
+`validation/generics.ts`:
+
+Validates generic type usage for C# compatibility:
+
+- **TSN7203**: Symbol keys in index signatures
+- **TSN7415**: Nullable unions with unconstrained generics
+
+```typescript
+// TSN7415: T | null where T is unconstrained
+function getValue<T>(value: T | null): T  // Error
+
+// Fix: Add constraint
+function getValue<T extends object>(value: T | null): T  // OK
+```
+
 ## IR Building
 
 ### Statement Conversion

--- a/docs/numeric-types.md
+++ b/docs/numeric-types.md
@@ -31,6 +31,41 @@ Import from `@tsonic/core`:
 | `ulong`    | `ulong`  | 0 to 18Q          | Large unsigned integers   |
 | `float`    | `float`  | ±3.4e38           | Single precision floats   |
 
+## Type Assertions for All Numeric Types
+
+The `as` keyword works with all numeric types, not just `int`:
+
+```typescript
+import { int, byte, short, long, float } from "@tsonic/core/types.js";
+
+// Integer types
+const intValue = 1000 as int;      // C#: int intValue = 1000;
+const byteValue = 255 as byte;     // C#: byte byteValue = 255;
+const shortValue = 1000 as short;  // C#: short shortValue = 1000;
+const longValue = 1000000 as long; // C#: long longValue = 1000000L;
+
+// Floating point
+const floatValue = 1.5 as float;   // C#: float floatValue = 1.5f;
+const doubleValue = 1.5 as number; // C#: double doubleValue = 1.5;
+```
+
+### Expression Casting
+
+Cast expressions to specific types:
+
+```typescript
+import { int, byte } from "@tsonic/core/types.js";
+
+const x = 100;
+const y = 50;
+
+// Cast result to specific type
+const intSum = (x + y) as int;     // C#: (int)(x + y)
+const byteVal = (x - y) as byte;   // C#: (byte)(x - y)
+```
+
+> **See also:** [Type Assertions in Type System](type-system.md#type-assertions) for reference type casting.
+
 ## Basic Usage
 
 ### Declaring Integer Variables

--- a/docs/type-system.md
+++ b/docs/type-system.md
@@ -393,6 +393,179 @@ Explicit types recommended for:
 - Function return types
 - Complex objects
 
+## Type Assertions
+
+Use the `as` keyword to perform type conversions.
+
+### Numeric Type Assertions
+
+Convert between numeric types explicitly:
+
+```typescript
+import { int, byte, short, long, float } from "@tsonic/core/types.js";
+
+// Literal to specific numeric type
+const intValue = 1000 as int;
+const byteValue = 255 as byte;
+const shortValue = 1000 as short;
+const longValue = 1000000 as long;
+const floatValue = 1.5 as float;
+const doubleValue = 1.5 as number;
+```
+
+Generates C# casts:
+
+```csharp
+int intValue = (int)1000;
+byte byteValue = (byte)255;
+short shortValue = (short)1000;
+long longValue = (long)1000000;
+float floatValue = (float)1.5;
+double doubleValue = 1.5;
+```
+
+> **See also:** [Numeric Types Guide](numeric-types.md) for complete coverage of numeric casting and overflow behavior.
+
+### Reference Type Assertions
+
+Downcast reference types:
+
+```typescript
+class Animal {
+  name!: string;
+}
+
+class Dog extends Animal {
+  breed!: string;
+}
+
+function getDog(animal: Animal): Dog {
+  return animal as Dog;
+}
+
+function castFromObject(obj: object): Animal {
+  return obj as Animal;
+}
+```
+
+Generates C# casts:
+
+```csharp
+public static Dog getDog(Animal animal)
+{
+    return (Dog)animal;
+}
+
+public static Animal castFromObject(object obj)
+{
+    return (Animal)obj;
+}
+```
+
+## Anonymous Objects
+
+Tsonic automatically synthesizes nominal classes for anonymous object type literals.
+
+### Inline Object Types
+
+When you use object type literals inline, Tsonic generates named classes:
+
+```typescript
+function createPoint(): { x: number; y: number } {
+  return { x: 10, y: 20 };
+}
+
+function processData(data: { id: number; name: string }): void {
+  console.log(data.name);
+}
+```
+
+Generates synthesized classes:
+
+```csharp
+// Auto-generated record class
+public record createPoint_Return(double x, double y);
+
+public record processData_data(double id, string name);
+
+public static createPoint_Return createPoint()
+{
+    return new createPoint_Return(10, 20);
+}
+
+public static void processData(processData_data data)
+{
+    Console.WriteLine(data.name);
+}
+```
+
+### When to Use Named Interfaces
+
+For reusable types, prefer explicit interfaces:
+
+```typescript
+// ✅ Preferred for reusable types
+interface Point {
+  x: number;
+  y: number;
+}
+
+function distance(a: Point, b: Point): number {
+  return Math.sqrt((b.x - a.x) ** 2 + (b.y - a.y) ** 2);
+}
+```
+
+Use anonymous object types for:
+
+- One-off return types
+- Function-specific parameters
+- Intermediate data shapes
+
+## Nullable Narrowing
+
+TypeScript null checks automatically narrow types in C#.
+
+### Reference Types
+
+```typescript
+function greet(name: string | null): string {
+  if (name !== null) {
+    return `Hello, ${name}`;
+  }
+  return "Hello, stranger";
+}
+```
+
+### Value Types
+
+Nullable value types require `.Value` access after null checks in C#. Tsonic handles this automatically:
+
+```typescript
+import { int } from "@tsonic/core/types.js";
+
+function processValue(value: int | null): int {
+  if (value !== null) {
+    return value * 2; // Narrowed to int
+  }
+  return 0 as int;
+}
+```
+
+Generates:
+
+```csharp
+public static int processValue(int? value)
+{
+    if (value != null)
+    {
+        return value.Value * 2;  // .Value access
+    }
+    return 0;
+}
+```
+
+> **See also:** [.NET Interop Guide](dotnet-interop.md#nullable-value-type-narrowing) for compound conditions and advanced nullable patterns.
+
 ## Unsupported Types
 
 | Type               | Reason            | Alternative                    |


### PR DESCRIPTION
Add documentation for 7 new features implemented since Dec 15:

- C# Attributes: Marker-call API (A.on(Class).type.add())
- Anonymous Object Type Lowering: Auto-synthesis of nominal classes
- Nullable Value Type Narrowing: .Value access after null checks
- Type Assertions: as keyword for type casting
- Parameter Modifiers: out/ref/in parameter handling
- TSN7415 Diagnostic: Nullable unions with unconstrained generics
- Golden Test Restructure: common/ vs js-only/ test organization

Updated files:
- docs/dotnet-interop.md (+145 lines)
- docs/type-system.md (+173 lines)
- docs/numeric-types.md (+35 lines)
- docs/diagnostics.md (+51 lines)
- docs/architecture/frontend.md (+50 lines)
- docs/architecture/emitter.md (+81 lines)
- docs/troubleshooting.md (+65 lines)

🤖 Generated with [Claude Code](https://claude.com/claude-code)