### PR TITLE
fix: Array<T> emits as native T[], remove JS mode remnants

### DIFF
--- a/packages/emitter/src/expressions/calls.ts
+++ b/packages/emitter/src/expressions/calls.ts
@@ -69,7 +69,7 @@ const isJsonSerializerCall = (
 
 /**
  * Check if a call targets global JSON.stringify or JSON.parse
- * These are JS-mode globals that should compile to JsonSerializer
+ * These global JSON methods compile to JsonSerializer
  */
 const isGlobalJsonCall = (
   callee: IrExpression
@@ -404,8 +404,12 @@ const emitListCollectionInitializer = (
 ): [CSharpFragment, EmitterContext] => {
   let currentContext = context;
 
-  // Get the element type
-  const elementType = expr.typeArguments![0]!;
+  // Get the element type (verified by isListConstructorWithArrayLiteral)
+  const typeArgs = expr.typeArguments;
+  const elementType = typeArgs?.[0];
+  if (!elementType) {
+    return [{ text: "new List<object>()" }, currentContext];
+  }
   const [elementTypeStr, typeContext] = emitType(elementType, currentContext);
   currentContext = typeContext;
 
@@ -481,8 +485,12 @@ const emitArrayConstructor = (
 ): [CSharpFragment, EmitterContext] => {
   let currentContext = context;
 
-  // Get the element type (we know typeArguments[0] exists from isArrayConstructorCall)
-  const elementType = expr.typeArguments![0]!;
+  // Get the element type (verified by isArrayConstructorCall)
+  const typeArgs = expr.typeArguments;
+  const elementType = typeArgs?.[0];
+  if (!elementType) {
+    return [{ text: "new object[0]" }, currentContext];
+  }
   const [elementTypeStr, typeContext] = emitType(elementType, currentContext);
   currentContext = typeContext;
 

--- a/packages/emitter/src/expressions/collections.ts
+++ b/packages/emitter/src/expressions/collections.ts
@@ -157,10 +157,7 @@ export const emitArray = (
     const firstSpread = spreadElements[0];
     if (!firstSpread) {
       // Should never happen due to allSpreads check, but satisfy TypeScript
-      return [
-        { text: "new global::System.Collections.Generic.List<object>()" },
-        currentContext,
-      ];
+      return [{ text: "new object[0]" }, currentContext];
     }
 
     const [firstFrag, firstContext] = emitExpression(

--- a/packages/emitter/src/invariants/emitter-globals-subset.test.ts
+++ b/packages/emitter/src/invariants/emitter-globals-subset.test.ts
@@ -2,7 +2,7 @@
  * Mechanical Invariant Test: Emitter Special-Cases ⊆ Globals
  *
  * This test verifies that every identifier the emitter "just knows" about
- * via special-casing exists in at least one globals package.
+ * via special-casing exists in the globals package.
  *
  * The principle: The emitter must not emit CLR mappings for types that
  * aren't declared in the globals packages. If a type isn't in globals,
@@ -17,46 +17,28 @@ import { strict as assert } from "assert";
 
 /**
  * Types that the emitter special-cases with hardcoded CLR mappings.
- * Each entry specifies which runtime mode(s) the special-casing applies to.
  *
  * IMPORTANT: When adding new special-cases to the emitter, you MUST:
  * 1. Add the type to this list
- * 2. Ensure the type is declared in the appropriate globals package(s)
+ * 2. Ensure the type is declared in the globals package
  * 3. Update the assertions below
  */
-const EMITTER_SPECIAL_CASES = {
-  // From references.ts:192 - Array<T> → List<T>
-  Array: { js: true, dotnet: true },
+const EMITTER_SPECIAL_CASES = [
+  // From references.ts:192 - Array<T> → T[] (native array)
+  "Array",
 
   // From references.ts:204,217 - Promise<T> → Task<T>
-  Promise: { js: true, dotnet: true },
+  "Promise",
 
-  // From references.ts:236 - PromiseLike<T> → Task<T>
-  PromiseLike: { js: true, dotnet: true },
-
-  // From references.ts:232 - Error → Exception (JS mode only)
-  Error: { js: true, dotnet: false },
-} as const;
+  // From references.ts:224 - PromiseLike<T> → Task<T>
+  "PromiseLike",
+] as const;
 
 /**
- * Types that MUST be declared in js-globals for the emitter to work correctly.
- * These are types that have special-case handling when runtime === "js".
+ * Types that are NOT in globals and must NOT be special-cased.
+ * These must fail at TS name resolution first.
  */
-const REQUIRED_IN_JS_GLOBALS = ["Array", "Promise", "PromiseLike", "Error"];
-
-/**
- * Types that MUST be declared in base globals for the emitter to work correctly.
- * These are types that have special-case handling when runtime === "dotnet".
- */
-const REQUIRED_IN_BASE_GLOBALS = ["Array", "Promise", "PromiseLike"];
-
-/**
- * Types that are NOT in any globals package.
- * These must NOT be special-cased because TS name resolution will fail first.
- * If the emitter special-cased these, it would produce wrong output for code
- * that can't even type-check.
- */
-const TYPES_NOT_IN_ANY_GLOBALS = [
+const TYPES_NOT_IN_GLOBALS = [
   "Map", // Not in globals - must fail at TS name resolution
   "Set", // Not in globals - must fail at TS name resolution
   "WeakMap", // Not in globals
@@ -69,128 +51,77 @@ const TYPES_NOT_IN_ANY_GLOBALS = [
 ];
 
 /**
- * Types that ARE in js-globals but are NOT special-cased by the emitter.
+ * Types that ARE in globals but are NOT special-cased by the emitter.
  * This is correct behavior - they go through normal type resolution.
- * These are listed here to document that they're intentionally not special-cased.
- *
- * Note: These types are legitimate in JS mode and resolve through the normal
- * import/binding path, not hardcoded CLR mappings.
  */
-const IN_JS_GLOBALS_NOT_SPECIAL_CASED = [
-  "console", // In js-globals, resolves via normal path
-  "Math", // In js-globals, resolves via normal path
-  "JSON", // In js-globals, resolves via normal path
-  "RegExp", // In js-globals (minimal), resolves via normal path
+const IN_GLOBALS_NOT_SPECIAL_CASED = [
+  "console", // In globals, resolves via normal path
+  "Math", // In globals, resolves via normal path
+  "JSON", // In globals, resolves via normal path
+  "RegExp", // In globals (minimal), resolves via normal path
 ];
 
 describe("Emitter-Globals Subset Invariant", () => {
-  describe("Special-cased types exist in appropriate globals", () => {
-    it("all JS-mode special cases are in js-globals", () => {
-      const jsSpecialCases = Object.entries(EMITTER_SPECIAL_CASES)
-        .filter(([_, modes]) => modes.js)
-        .map(([name]) => name);
-
-      // This assertion documents the invariant
+  describe("Special-cased types exist in globals", () => {
+    it("documents all special-cased types", () => {
       assert.deepEqual(
-        jsSpecialCases.sort(),
-        REQUIRED_IN_JS_GLOBALS.sort(),
-        "JS-mode special cases must match required js-globals types"
-      );
-    });
-
-    it("all dotnet-mode special cases are in base globals", () => {
-      const dotnetSpecialCases = Object.entries(EMITTER_SPECIAL_CASES)
-        .filter(([_, modes]) => modes.dotnet)
-        .map(([name]) => name);
-
-      assert.deepEqual(
-        dotnetSpecialCases.sort(),
-        REQUIRED_IN_BASE_GLOBALS.sort(),
-        "Dotnet-mode special cases must match required base globals types"
-      );
-    });
-
-    it("Error is only special-cased in JS mode", () => {
-      const errorConfig = EMITTER_SPECIAL_CASES.Error;
-      assert.equal(
-        errorConfig.js,
-        true,
-        "Error should be special-cased in JS mode"
-      );
-      assert.equal(
-        errorConfig.dotnet,
-        false,
-        "Error should NOT be special-cased in dotnet mode"
+        [...EMITTER_SPECIAL_CASES].sort(),
+        ["Array", "Promise", "PromiseLike"],
+        "Complete list of emitter special-cased types"
       );
     });
   });
 
   describe("Types not in globals are not special-cased", () => {
-    it("Map is not special-cased (not in any globals)", () => {
-      assert.equal(
-        (EMITTER_SPECIAL_CASES as Record<string, unknown>)["Map"],
-        undefined,
+    it("Map is not special-cased (not in globals)", () => {
+      assert.ok(
+        !EMITTER_SPECIAL_CASES.includes("Map" as never),
         "Map must not be special-cased - it's not in globals, TS will fail first"
       );
     });
 
-    it("Set is not special-cased (not in any globals)", () => {
-      assert.equal(
-        (EMITTER_SPECIAL_CASES as Record<string, unknown>)["Set"],
-        undefined,
+    it("Set is not special-cased (not in globals)", () => {
+      assert.ok(
+        !EMITTER_SPECIAL_CASES.includes("Set" as never),
         "Set must not be special-cased - it's not in globals, TS will fail first"
       );
     });
 
     it("no types outside globals are special-cased", () => {
-      for (const typeName of TYPES_NOT_IN_ANY_GLOBALS) {
-        assert.equal(
-          (EMITTER_SPECIAL_CASES as Record<string, unknown>)[typeName],
-          undefined,
-          `${typeName} must not be special-cased - it's not in any globals package`
+      for (const typeName of TYPES_NOT_IN_GLOBALS) {
+        assert.ok(
+          !EMITTER_SPECIAL_CASES.includes(typeName as never),
+          `${typeName} must not be special-cased - it's not in globals`
         );
       }
     });
   });
 
-  describe("JS-globals types correctly handled", () => {
-    it("console/Math/JSON are in js-globals but not special-cased (correct)", () => {
-      // These types ARE in js-globals and should NOT be special-cased.
+  describe("Globals types correctly handled", () => {
+    it("console/Math/JSON are in globals but not special-cased (correct)", () => {
+      // These types ARE in globals and should NOT be special-cased.
       // They resolve through normal type resolution, not hardcoded CLR mappings.
-      for (const typeName of IN_JS_GLOBALS_NOT_SPECIAL_CASED) {
-        assert.equal(
-          (EMITTER_SPECIAL_CASES as Record<string, unknown>)[typeName],
-          undefined,
-          `${typeName} is in js-globals but should NOT be special-cased (uses normal resolution)`
+      for (const typeName of IN_GLOBALS_NOT_SPECIAL_CASED) {
+        assert.ok(
+          !EMITTER_SPECIAL_CASES.includes(typeName as never),
+          `${typeName} is in globals but should NOT be special-cased (uses normal resolution)`
         );
       }
     });
   });
 
   describe("Invariant documentation", () => {
-    it("documents the complete list of special-cased types", () => {
-      const specialCasedTypes = Object.keys(EMITTER_SPECIAL_CASES);
-
-      // This test will fail if someone adds a new special case without updating this file
-      assert.deepEqual(
-        specialCasedTypes.sort(),
-        ["Array", "Error", "Promise", "PromiseLike"],
-        "Complete list of emitter special-cased types"
-      );
-    });
-
     it("documents source locations for special cases", () => {
       // This is a documentation test - it reminds maintainers where to look
-      const sourceLocations = {
+      const sourceLocations: Record<string, string> = {
         Array: "packages/emitter/src/types/references.ts:192",
         Promise: "packages/emitter/src/types/references.ts:204,217",
-        PromiseLike: "packages/emitter/src/types/references.ts:236",
-        Error: "packages/emitter/src/types/references.ts:232",
+        PromiseLike: "packages/emitter/src/types/references.ts:224",
       };
 
       assert.equal(
         Object.keys(sourceLocations).length,
-        Object.keys(EMITTER_SPECIAL_CASES).length,
+        EMITTER_SPECIAL_CASES.length,
         "All special cases should have documented source locations"
       );
     });

--- a/packages/emitter/src/specialization/type-aliases.test.ts
+++ b/packages/emitter/src/specialization/type-aliases.test.ts
@@ -218,7 +218,7 @@ describe("Type Aliases (spec/16 §3)", () => {
     );
     // Array of PersonData should also use __Alias suffix
     expect(result).to.include(
-      "public required global::System.Collections.Generic.List<PersonData__Alias> items { get; set; }"
+      "public required PersonData__Alias[] items { get; set; }"
     );
   });
 });

--- a/packages/emitter/src/types/references.test.ts
+++ b/packages/emitter/src/types/references.test.ts
@@ -111,7 +111,7 @@ describe("Reference Type Emission", () => {
   });
 
   describe("Known Builtin Types", () => {
-    it("should emit Array<T> as List<T>", () => {
+    it("should emit Array<T> as native T[] array", () => {
       const module = createModuleWithType({
         kind: "referenceType",
         name: "Array",
@@ -120,9 +120,8 @@ describe("Reference Type Emission", () => {
 
       const result = emitModule(module);
 
-      expect(result).to.include(
-        "global::System.Collections.Generic.List<double>"
-      );
+      expect(result).to.include("double[]");
+      expect(result).not.to.include("List");
     });
 
     it("should emit Promise<T> as Task<T>", () => {

--- a/packages/emitter/src/types/references.ts
+++ b/packages/emitter/src/types/references.ts
@@ -189,16 +189,15 @@ export const emitReferenceType = (
   }
 
   // Handle built-in types
+  // Array<T> emits as native T[] array, same as T[] syntax
+  // Users must explicitly use List<T> to get a List
   if (name === "Array" && typeArguments && typeArguments.length > 0) {
     const firstArg = typeArguments[0];
     if (!firstArg) {
-      return [`global::System.Collections.Generic.List<object>`, context];
+      return [`object[]`, context];
     }
     const [elementType, newContext] = emitType(firstArg, context);
-    return [
-      `global::System.Collections.Generic.List<${elementType}>`,
-      newContext,
-    ];
+    return [`${elementType}[]`, newContext];
   }
 
   if (name === "Promise" && typeArguments && typeArguments.length > 0) {

--- a/packages/frontend/src/ir/converters/expressions/access.ts
+++ b/packages/frontend/src/ir/converters/expressions/access.ts
@@ -13,8 +13,7 @@ import { getBindingRegistry } from "../statements/declarations/registry.js";
  * This determines whether Int32 proof is required for the index.
  *
  * Classification is based on IR type kinds, NOT string matching.
- * Both jsRuntimeArray (JS mode) and clrIndexer (dotnet mode) require Int32 proof,
- * so we use clrIndexer as the default for TypeScript arrays.
+ * CLR indexers (arrays, List<T>, etc.) require Int32 proof for indices.
  *
  * IMPORTANT: If classification cannot be determined reliably, returns "unknown"
  * which causes a compile-time error (TSN5109). This is safer than misclassifying.

--- a/packages/frontend/src/ir/converters/expressions/calls.ts
+++ b/packages/frontend/src/ir/converters/expressions/calls.ts
@@ -530,9 +530,15 @@ export const convertCallExpression = (
     node.arguments.length === 1
   ) {
     // We've verified length === 1 above, so these are guaranteed to exist
-    const targetTypeNode = node.typeArguments[0]!;
+    const targetTypeNode = node.typeArguments[0];
+    const argNode = node.arguments[0];
+    if (!targetTypeNode || !argNode) {
+      throw new Error(
+        "ICE: tryCast requires exactly 1 type argument and 1 argument"
+      );
+    }
     const targetType = convertType(targetTypeNode, checker);
-    const argExpr = convertExpression(node.arguments[0]!, checker);
+    const argExpr = convertExpression(argNode, checker);
 
     // Build union type T | null for inferredType
     const nullType: IrType = { kind: "primitiveType", name: "null" };

--- a/packages/frontend/src/ir/types/ir-types.ts
+++ b/packages/frontend/src/ir/types/ir-types.ts
@@ -78,9 +78,8 @@ export type IrArrayType = {
    * Set to "explicit" when the array type came from an explicit T[] annotation.
    * Undefined when the type was inferred.
    *
-   * In dotnet mode:
-   * - origin: "explicit" → emit native CLR array (T[])
-   * - origin: undefined → emit List<T>
+   * All array types emit as native CLR arrays (T[]).
+   * Users must explicitly use List<T> to get a List.
    */
   readonly origin?: "explicit";
 };

--- a/packages/frontend/src/program/index.ts
+++ b/packages/frontend/src/program/index.ts
@@ -2,7 +2,7 @@
  * Program - Public API
  */
 
-export type { CompilerOptions, TsonicProgram, RuntimeMode } from "./types.js";
+export type { CompilerOptions, TsonicProgram } from "./types.js";
 export { defaultTsConfig } from "./config.js";
 export { loadDotnetMetadata } from "./metadata.js";
 export { BindingRegistry, loadBindings, type TypeBinding } from "./bindings.js";

--- a/packages/frontend/src/program/types.ts
+++ b/packages/frontend/src/program/types.ts
@@ -7,8 +7,6 @@ import { DotnetMetadataRegistry } from "../dotnet-metadata.js";
 import { BindingRegistry } from "./bindings.js";
 import { ClrBindingsResolver } from "../resolver/clr-bindings-resolver.js";
 
-export type RuntimeMode = "js" | "dotnet";
-
 export type CompilerOptions = {
   readonly projectRoot: string; // Directory containing package.json (for node_modules resolution)
   readonly sourceRoot: string;
@@ -18,13 +16,6 @@ export type CompilerOptions = {
   readonly verbose?: boolean;
   /** Use TypeScript standard lib (Array, Promise, etc.) instead of noLib mode */
   readonly useStandardLib?: boolean;
-  /**
-   * Runtime mode:
-   * - "js": JS built-ins available via Tsonic.JSRuntime
-   * - "dotnet": Pure .NET mode, JS built-ins forbidden
-   * Defaults to "js"
-   */
-  readonly runtime?: RuntimeMode;
 };
 
 export type TsonicProgram = {


### PR DESCRIPTION
- Array<T> now emits as native T[] instead of List<T>
  - Users must explicitly use List<T> to get a List
  - Updated references.ts, tests, and comments

- Removed JS mode remnants:
  - Removed RuntimeMode type and runtime option from CompilerOptions
  - Simplified emitter-globals-subset.test.ts (no more js/dotnet mode flags)
  - Updated comments that referenced JS mode

- Fixed lint errors:
  - Replaced non-null assertions with proper null checks in calls.ts

🤖 Generated with [Claude Code](https://claude.com/claude-code)