### PR TITLE
fix: Remove JSRuntime references from build scripts

### DIFF
--- a/scripts/build/npm.sh
+++ b/scripts/build/npm.sh
@@ -19,7 +19,6 @@ echo ""
 
 # Step 1: Build runtime packages from sibling directories
 RUNTIME_DIR="$ROOT_DIR/../runtime"
-JSRUNTIME_DIR="$ROOT_DIR/../js-runtime"
 NODEJS_DIR="$ROOT_DIR/../nodejs-clr"
 
 echo -e "${YELLOW}Building Tsonic.Runtime...${NC}"
@@ -30,17 +29,6 @@ if [[ -d "$RUNTIME_DIR" ]]; then
   echo -e "${GREEN}  Tsonic.Runtime built${NC}"
 else
   echo -e "${RED}  Error: runtime repo not found at $RUNTIME_DIR${NC}"
-  exit 1
-fi
-
-echo -e "${YELLOW}Building Tsonic.JSRuntime...${NC}"
-if [[ -d "$JSRUNTIME_DIR" ]]; then
-  cd "$JSRUNTIME_DIR"
-  git pull
-  dotnet build -c Release
-  echo -e "${GREEN}  Tsonic.JSRuntime built${NC}"
-else
-  echo -e "${RED}  Error: js-runtime repo not found at $JSRUNTIME_DIR${NC}"
   exit 1
 fi
 
@@ -89,20 +77,6 @@ if [[ -f "$RUNTIME_SRC/Tsonic.Runtime.dll" ]]; then
 else
   echo -e "${RED}  Warning: Tsonic.Runtime.dll not found at $RUNTIME_SRC${NC}"
   echo -e "${YELLOW}  Build it with: cd ../runtime && dotnet build -c Release${NC}"
-fi
-
-# Tsonic.JSRuntime (for js mode)
-JSRUNTIME_SRC="$ROOT_DIR/../js-runtime/artifacts/bin/Tsonic.JSRuntime/Release/net10.0"
-if [[ -f "$JSRUNTIME_SRC/Tsonic.JSRuntime.dll" ]]; then
-  cp "$JSRUNTIME_SRC/Tsonic.JSRuntime.dll" "$NPM_DIR/runtime/"
-  # JSRuntime also needs its dependency on Tsonic.Runtime
-  if [[ -f "$JSRUNTIME_SRC/Tsonic.Runtime.dll" ]]; then
-    cp "$JSRUNTIME_SRC/Tsonic.Runtime.dll" "$NPM_DIR/runtime/Tsonic.Runtime.JSRuntime.dll"
-  fi
-  echo -e "${GREEN}  Copied Tsonic.JSRuntime.dll${NC}"
-else
-  echo -e "${RED}  Warning: Tsonic.JSRuntime.dll not found at $JSRUNTIME_SRC${NC}"
-  echo -e "${YELLOW}  Build it with: cd ../js-runtime && dotnet build -c Release${NC}"
 fi
 
 # nodejs-clr (for --nodejs flag)

--- a/scripts/publish-npm.sh
+++ b/scripts/publish-npm.sh
@@ -12,7 +12,6 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 WRAPPER_DIR="$(cd "$ROOT_DIR/../tsonic-wrapper" && pwd)"
 RUNTIME_DIR="$(cd "$ROOT_DIR/../runtime" && pwd)"
-JSRUNTIME_DIR="$(cd "$ROOT_DIR/../js-runtime" && pwd)"
 NODEJS_CLR_DIR="$(cd "$ROOT_DIR/../nodejs-clr" && pwd)"
 
 # Parse arguments
@@ -118,7 +117,6 @@ fi
 echo "=== Checking runtime dependencies ==="
 RUNTIME_PROJECTS=(
     "$RUNTIME_DIR:runtime"
-    "$JSRUNTIME_DIR:js-runtime"
     "$NODEJS_CLR_DIR:nodejs-clr"
 )
 
@@ -141,10 +139,6 @@ echo "  Building runtime..."
 cd "$RUNTIME_DIR"
 dotnet build -c Release --verbosity quiet
 
-echo "  Building js-runtime..."
-cd "$JSRUNTIME_DIR"
-dotnet build -c Release --verbosity quiet
-
 echo "  Building nodejs-clr..."
 cd "$NODEJS_CLR_DIR"
 dotnet build -c Release --verbosity quiet
@@ -153,7 +147,6 @@ cd "$ROOT_DIR"
 
 echo "=== Copying runtime DLLs ==="
 cp "$RUNTIME_DIR/artifacts/bin/Tsonic.Runtime/Release/net10.0/Tsonic.Runtime.dll" "$ROOT_DIR/packages/cli/runtime/"
-cp "$JSRUNTIME_DIR/artifacts/bin/Tsonic.JSRuntime/Release/net10.0/Tsonic.JSRuntime.dll" "$ROOT_DIR/packages/cli/runtime/"
 cp "$NODEJS_CLR_DIR/artifacts/bin/nodejs/Release/net10.0/nodejs.dll" "$ROOT_DIR/packages/cli/runtime/"
 echo "  Copied all runtime DLLs ✓"
 


### PR DESCRIPTION
- Remove js-runtime build steps from npm.sh
- Remove JSRuntime.dll copy from publish-npm.sh
- Remove js-runtime from runtime dependencies check

🤖 Generated with [Claude Code](https://claude.com/claude-code)