### PR TITLE
feat: Implement typed array emission with numeric suffixes

### DIFF
--- a/.analysis/var-vs-explicit.md
+++ b/.analysis/var-vs-explicit.md
@@ -1,163 +1,175 @@
 ---
-  Detailed Analysis of feat/explicit-type-emission vs main
+Detailed Analysis of feat/explicit-type-emission vs main
 
-  Summary
+Summary
 
-  | Category                             | Count       |
-  |--------------------------------------|-------------|
-  | Source files modified                | 5           |
-  | Unit test files modified             | 2           |
-  | New golden test inputs               | 18          |
-  | New golden test expected outputs     | 18          |
-  | Updated golden test expected outputs | 6           |
-  | New E2E test                         | 1 (5 files) |
-  | Other                                | 2           |
-  | Total lines                          | +655 / -63  |
+| Category                             | Count       |
+| ------------------------------------ | ----------- |
+| Source files modified                | 5           |
+| Unit test files modified             | 2           |
+| New golden test inputs               | 18          |
+| New golden test expected outputs     | 18          |
+| Updated golden test expected outputs | 6           |
+| New E2E test                         | 1 (5 files) |
+| Other                                | 2           |
+| Total lines                          | +655 / -63  |
+---
 
-  ---
-  1. SOURCE CODE CHANGES
+1. SOURCE CODE CHANGES
 
-  1.1 collections.ts - Array Literal Emission
+1.1 collections.ts - Array Literal Emission
 
-  Change: new[] → new T[]
+Change: new[] → new T[]
 
-  // BEFORE (main)
-  new[] { 1, 2, 3 }
+// BEFORE (main)
+new[] { 1, 2, 3 }
 
-  // AFTER (feature)
-  new int[] { 1, 2, 3 }
+// AFTER (feature)
+new int[] { 1, 2, 3 }
 
-  Also: Pass expectedElementType to each element so literals get proper suffixes.
+Also: Pass expectedElementType to each element so literals get proper suffixes.
 
-  Why needed: For long[] arrays, C# can't infer from new[] { 1, 2, 3 }. Need new long[] { 1L, 2L, 3L }.
+Why needed: For long[] arrays, C# can't infer from new[] { 1, 2, 3 }. Need new long[] { 1L, 2L, 3L }.
 
-  ---
-  1.2 literals.ts - Numeric Suffix Support
+---
 
-  New function: getNumericSuffix(typeName)
+1.2 literals.ts - Numeric Suffix Support
 
-  case "long": return "L";
-  case "uint": return "U";
-  case "ulong": return "UL";
-  case "float": return "f";
-  case "decimal": return "m";
-  default: return "";  // int, byte, short, double - no suffix
+New function: getNumericSuffix(typeName)
 
-  Change: When emitting a number literal with an expectedType, append the appropriate suffix.
+case "long": return "L";
+case "uint": return "U";
+case "ulong": return "UL";
+case "float": return "f";
+case "decimal": return "m";
+default: return ""; // int, byte, short, double - no suffix
 
-  Examples:
-  - long[] elements: 1 → 1L
-  - float[] elements: 1.5 → 1.5f
-  - decimal[] elements: 1.5 → 1.5m
+Change: When emitting a number literal with an expectedType, append the appropriate suffix.
 
-  ---
-  1.3 variables.ts - Variable Type Emission
+Examples:
 
-  New function: canEmitTypeExplicitly(type) - Recursively checks if a type can be emitted (rejects any, objectType, tuples/arrays/unions
-  containing them).
+- long[] elements: 1 → 1L
+- float[] elements: 1.5 → 1.5f
+- decimal[] elements: 1.5 → 1.5m
 
-  Change in static context: Added canEmitTypeExplicitly(decl.type) guard to skip anonymous object types.
+---
 
-  Change in non-static context:
-  // BEFORE (main)
-  varDecl += "var ";
+1.3 variables.ts - Variable Type Emission
 
-  // AFTER (feature)
-  if (decl.initializer?.kind === "literal") {
-    // Emit explicit type based on numericIntent
-    // string → "string", number → int/double, boolean → "bool"
-  } else {
-    varDecl += "var ";
-  }
+New function: canEmitTypeExplicitly(type) - Recursively checks if a type can be emitted (rejects any, objectType, tuples/arrays/unions
+containing them).
 
-  Result:
-  - const x = 10; → int x = 10; (was var x = 10;)
-  - const x = 10.5; → double x = 10.5; (was var x = 10.5;)
-  - const x = func(); → var x = func(); (unchanged)
+Change in static context: Added canEmitTypeExplicitly(decl.type) guard to skip anonymous object types.
 
-  ---
-  1.4 numeric-proof-pass.ts - Comparison Operator Bug Fix
+Change in non-static context:
+// BEFORE (main)
+varDecl += "var ";
 
-  New constant: NUMERIC_RESULT_OPERATORS - Set of operators that return numeric types (arithmetic + bitwise).
+// AFTER (feature)
+if (decl.initializer?.kind === "literal") {
+// Emit explicit type based on numericIntent
+// string → "string", number → int/double, boolean → "bool"
+} else {
+varDecl += "var ";
+}
 
-  Bug fixed: Comparison operators (<, >, <=, >=, ==, !=, ===, !==) were incorrectly getting numeric inferredType annotations.
+Result:
 
-  Fix: Skip numeric type annotation for comparison operators - they return boolean, not int.
+- const x = 10; → int x = 10; (was var x = 10;)
+- const x = 10.5; → double x = 10.5; (was var x = 10.5;)
+- const x = func(); → var x = func(); (unchanged)
 
-  ---
-  2. UNIT TEST CHANGES
+---
 
-  2.1 array.test.ts
+1.4 numeric-proof-pass.ts - Comparison Operator Bug Fix
 
-  Updated expectations from new[] to new T[]:
-  - new[] { 1, 2, 3 } → new double[] { 1, 2, 3 }
-  - new[] { 1, default, 3 } → new double[] { 1, default, 3 }
-  - new[] { "hello", "world" } → new string[] { "hello", "world" }
+New constant: NUMERIC_RESULT_OPERATORS - Set of operators that return numeric types (arithmetic + bitwise).
+
+Bug fixed: Comparison operators (<, >, <=, >=, ==, !=, ===, !==) were incorrectly getting numeric inferredType annotations.
+
+Fix: Skip numeric type annotation for comparison operators - they return boolean, not int.
+
+---
+
+2. UNIT TEST CHANGES
+
+2.1 array.test.ts
+
+Updated expectations from new[] to new T[]:
+
+- new[] { 1, 2, 3 } → new double[] { 1, 2, 3 }
+- new[] { 1, default, 3 } → new double[] { 1, default, 3 }
+- new[] { "hello", "world" } → new string[] { "hello", "world" }
 
   2.2 index.test.ts
 
-  - new[] { 1, 2, 3 } → new int[] { 1, 2, 3 }
+- new[] { 1, 2, 3 } → new int[] { 1, 2, 3 }
 
-  ---
-  3. NEW GOLDEN TESTS (18)
+---
 
-  All in testcases/common/arrays/explicit-types/:
+3. NEW GOLDEN TESTS (18)
 
-  | File                         | Input                                       | Expected Output                                  |
-  |------------------------------|---------------------------------------------|--------------------------------------------------|
-  | IntArrayLiteral.ts           | int[] = [1,2,3]                             | new int[] { 1, 2, 3 }                            |
-  | LongArrayLiteral.ts          | long[] = [1,2,3]                            | new long[] { 1L, 2L, 3L }                        |
-  | FloatArrayLiteral.ts         | float[] = [1,2,3]                           | new float[] { 1f, 2f, 3f }                       |
-  | DecimalArrayLiteral.ts       | decimal[] = [1,2,3]                         | new decimal[] { 1m, 2m, 3m }                     |
-  | UintArrayLiteral.ts          | uint[] = [1,2,3]                            | new uint[] { 1U, 2U, 3U }                        |
-  | UlongArrayLiteral.ts         | ulong[] = [1,2,3]                           | new ulong[] { 1UL, 2UL, 3UL }                    |
-  | ByteArrayLiteral.ts          | byte[] = [1,2,3]                            | new byte[] { 1, 2, 3 }                           |
-  | ShortArrayLiteral.ts         | short[] = [1,2,3]                           | new short[] { 1, 2, 3 }                          |
-  | SbyteArrayLiteral.ts         | sbyte[] = [1,2,3]                           | new sbyte[] { 1, 2, 3 }                          |
-  | UshortArrayLiteral.ts        | ushort[] = [1,2,3]                          | new ushort[] { 1, 2, 3 }                         |
-  | DoubleArrayLiteral.ts        | number[] = [1,2,3]                          | new double[] { 1, 2, 3 }                         |
-  | StringArrayExplicit.ts       | string[] = ["a","b","c"]                    | new string[] { "a", "b", "c" }                   |
-  | NestedLongArray.ts           | long[][] = [[1,2],[3,4]]                    | new long[][] { new long[] { 1L, 2L }, ... }      |
-  | NestedFloatArray.ts          | float[][] = [[1.5,2.5],...]                 | new float[][] { new float[] { 1.5f, ... }, ... } |
-  | ThreeDimensionalLongArray.ts | long[][][]                                  | 3D with L suffixes                               |
-  | MixedFloatLiterals.ts        | float[] = [1, 2.5, 3]                       | new float[] { 1f, 2.5f, 3f }                     |
-  | EmptyArrayTypes.ts           | Empty long[], float[], decimal[]            | Array.Empty<T>()                                 |
-  | VariableInference.ts         | const x=10; const y=10.5; const arr=[1,2,3] | int x; double y; var arr                         |
+All in testcases/common/arrays/explicit-types/:
 
-  ---
-  4. UPDATED GOLDEN TESTS (6)
+| File                         | Input                                       | Expected Output                                  |
+| ---------------------------- | ------------------------------------------- | ------------------------------------------------ |
+| IntArrayLiteral.ts           | int[] = [1,2,3]                             | new int[] { 1, 2, 3 }                            |
+| LongArrayLiteral.ts          | long[] = [1,2,3]                            | new long[] { 1L, 2L, 3L }                        |
+| FloatArrayLiteral.ts         | float[] = [1,2,3]                           | new float[] { 1f, 2f, 3f }                       |
+| DecimalArrayLiteral.ts       | decimal[] = [1,2,3]                         | new decimal[] { 1m, 2m, 3m }                     |
+| UintArrayLiteral.ts          | uint[] = [1,2,3]                            | new uint[] { 1U, 2U, 3U }                        |
+| UlongArrayLiteral.ts         | ulong[] = [1,2,3]                           | new ulong[] { 1UL, 2UL, 3UL }                    |
+| ByteArrayLiteral.ts          | byte[] = [1,2,3]                            | new byte[] { 1, 2, 3 }                           |
+| ShortArrayLiteral.ts         | short[] = [1,2,3]                           | new short[] { 1, 2, 3 }                          |
+| SbyteArrayLiteral.ts         | sbyte[] = [1,2,3]                           | new sbyte[] { 1, 2, 3 }                          |
+| UshortArrayLiteral.ts        | ushort[] = [1,2,3]                          | new ushort[] { 1, 2, 3 }                         |
+| DoubleArrayLiteral.ts        | number[] = [1,2,3]                          | new double[] { 1, 2, 3 }                         |
+| StringArrayExplicit.ts       | string[] = ["a","b","c"]                    | new string[] { "a", "b", "c" }                   |
+| NestedLongArray.ts           | long[][] = [[1,2],[3,4]]                    | new long[][] { new long[] { 1L, 2L }, ... }      |
+| NestedFloatArray.ts          | float[][] = [[1.5,2.5],...]                 | new float[][] { new float[] { 1.5f, ... }, ... } |
+| ThreeDimensionalLongArray.ts | long[][][]                                  | 3D with L suffixes                               |
+| MixedFloatLiterals.ts        | float[] = [1, 2.5, 3]                       | new float[] { 1f, 2.5f, 3f }                     |
+| EmptyArrayTypes.ts           | Empty long[], float[], decimal[]            | Array.Empty<T>()                                 |
+| VariableInference.ts         | const x=10; const y=10.5; const arr=[1,2,3] | int x; double y; var arr                         |
 
-  | File                | Change                                                        |
-  |---------------------|---------------------------------------------------------------|
-  | ArrayLiteral.cs     | new[] → new int[]                                             |
-  | MultiDimensional.cs | new[] { new[] {...} } → new double[][] { new double[] {...} } |
-  | NestedScopes.cs     | var a = 10 → int a = 10 (×3 variables)                        |
-  | Shadowing.cs        | var x = 10 → int x = 10 (×4 variables)                        |
-  | Closures.cs         | var count = 0 → int count = 0                                 |
-  | TypeAssertions.cs   | Added L suffix for long, f suffix for float                   |
-  | VariableDecls.cs    | var → explicit types for literals, added suffixes             |
+---
 
-  ---
-  5. NEW E2E TEST
+4. UPDATED GOLDEN TESTS (6)
 
-  test/fixtures/array-type-emission/ - Tests all numeric array types compile and run:
-  - int[], long[], byte[], short[], sbyte[], ushort[]
-  - float[], double[], decimal[]
-  - uint[], ulong[]
-  - 2D arrays: long[][], float[][]
+| File                | Change                                                        |
+| ------------------- | ------------------------------------------------------------- |
+| ArrayLiteral.cs     | new[] → new int[]                                             |
+| MultiDimensional.cs | new[] { new[] {...} } → new double[][] { new double[] {...} } |
+| NestedScopes.cs     | var a = 10 → int a = 10 (×3 variables)                        |
+| Shadowing.cs        | var x = 10 → int x = 10 (×4 variables)                        |
+| Closures.cs         | var count = 0 → int count = 0                                 |
+| TypeAssertions.cs   | Added L suffix for long, f suffix for float                   |
+| VariableDecls.cs    | var → explicit types for literals, added suffixes             |
 
-  ---
-  6. KEY OBSERVATIONS
+---
 
-  What WAS Needed:
+5. NEW E2E TEST
 
-  1. ✅ new[] → new T[] for arrays (required for long[], float[], etc.)
-  2. ✅ Literal suffixes (L, f, m, U, UL) for non-default numeric types
-  3. ✅ Comparison operator bug fix
+test/fixtures/array-type-emission/ - Tests all numeric array types compile and run:
 
-  What Was OPTIONAL (but done):
+- int[], long[], byte[], short[], sbyte[], ushort[]
+- float[], double[], decimal[]
+- uint[], ulong[]
+- 2D arrays: long[][], float[][]
 
-  4. ⚠️ var x = 10 → int x = 10 for literal initializers
+---
 
-  The var → explicit type change for literals is unnecessary - C# correctly infers int from var x = 10. However, it doesn't break anything and
-  is more explicit.
+6. KEY OBSERVATIONS
+
+What WAS Needed:
+
+1. ✅ new[] → new T[] for arrays (required for long[], float[], etc.)
+2. ✅ Literal suffixes (L, f, m, U, UL) for non-default numeric types
+3. ✅ Comparison operator bug fix
+
+What Was OPTIONAL (but done):
+
+4. ⚠️ var x = 10 → int x = 10 for literal initializers
+
+The var → explicit type change for literals is unnecessary - C# correctly infers int from var x = 10. However, it doesn't break anything and
+is more explicit.

--- a/docs/architecture/emitter.md
+++ b/docs/architecture/emitter.md
@@ -338,6 +338,7 @@ Lowers destructuring patterns to C# statements:
 ```
 
 Lowering functions:
+
 - `lowerPattern()` - General pattern lowering for declarations
 - `lowerForOfPattern()` - Pattern lowering in for-of loops
 - `lowerParameterPattern()` - Parameter destructuring in functions

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -20,13 +20,13 @@ tsonic project init [options]
 
 **Options:**
 
-| Option                  | Description                                   | Default |
-| ----------------------- | --------------------------------------------- | ------- |
-| `--js`                  | Enable JS stdlib (installs @tsonic/js)        | `false` |
-| `--nodejs`              | Enable Node.js interop (installs @tsonic/nodejs) | `false` |
+| Option                  | Description                                               | Default |
+| ----------------------- | --------------------------------------------------------- | ------- |
+| `--js`                  | Enable JS stdlib (installs @tsonic/js)                    | `false` |
+| `--nodejs`              | Enable Node.js interop (installs @tsonic/nodejs)          | `false` |
 | `--pure`                | Use PascalCase CLR naming (installs @tsonic/globals-pure) | `false` |
-| `--skip-types`          | Skip installing type declarations             | `false` |
-| `--types-version <ver>` | Version of type declarations                  | Latest  |
+| `--skip-types`          | Skip installing type declarations                         | `false` |
+| `--types-version <ver>` | Version of type declarations                              | Latest  |
 
 **Examples:**
 
@@ -300,17 +300,17 @@ These options work with all commands:
 
 ## Exit Codes
 
-| Code | Meaning                  |
-| ---- | ------------------------ |
-| 0    | Success                  |
-| 1    | Generic error            |
-| 2    | Unknown command          |
-| 3    | No tsonic.json found     |
-| 5    | Generate/emit failed     |
-| 6    | Build failed             |
-| 7    | Run failed               |
-| 8    | .NET SDK not found       |
-| 9    | Pack failed              |
+| Code | Meaning              |
+| ---- | -------------------- |
+| 0    | Success              |
+| 1    | Generic error        |
+| 2    | Unknown command      |
+| 3    | No tsonic.json found |
+| 5    | Generate/emit failed |
+| 6    | Build failed         |
+| 7    | Run failed           |
+| 8    | .NET SDK not found   |
+| 9    | Pack failed          |
 
 ## Environment Variables
 

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -511,6 +511,7 @@ function process(user: User): void {
 ### TSN7423: Unsupported Destructuring Pattern
 
 The destructuring pattern is not supported. This may include:
+
 - Computed property keys in destructuring
 - Patterns that cannot be lowered to C#
 

--- a/docs/language.md
+++ b/docs/language.md
@@ -295,20 +295,30 @@ const { host = "localhost", port = 8080 } = config;
 
 ```typescript
 // Nested object destructuring
-const { address: { city, zip } } = user;
+const {
+  address: { city, zip },
+} = user;
 
 // Nested array destructuring
-const [[a, b], [c, d]] = [[1, 2], [3, 4]];
+const [[a, b], [c, d]] = [
+  [1, 2],
+  [3, 4],
+];
 
 // Mixed nesting
-const { items: [first, second] } = order;
+const {
+  items: [first, second],
+} = order;
 ```
 
 #### For-of Destructuring
 
 ```typescript
 // Destructure in for-of loops
-const entries = [["a", 1], ["b", 2]];
+const entries = [
+  ["a", 1],
+  ["b", 2],
+];
 for (const [key, value] of entries) {
   console.log(`${key}: ${value}`);
 }
@@ -345,7 +355,7 @@ function connect({ host = "localhost", port = 80 }: Config): void {
 let a: number, b: number;
 
 // Assign via destructuring (parentheses required)
-([a, b] = [1, 2]);
+[a, b] = [1, 2];
 ({ x: a, y: b } = point);
 ```
 

--- a/docs/type-system.md
+++ b/docs/type-system.md
@@ -516,12 +516,13 @@ public static void process(Animal animal)
 
 **Difference from type assertions:**
 
-| Syntax | C# Code | On Failure |
-|--------|---------|------------|
-| `value as T` | `(T)value` | Throws `InvalidCastException` |
-| `trycast<T>(value)` | `value as T` | Returns `null` |
+| Syntax              | C# Code      | On Failure                    |
+| ------------------- | ------------ | ----------------------------- |
+| `value as T`        | `(T)value`   | Throws `InvalidCastException` |
+| `trycast<T>(value)` | `value as T` | Returns `null`                |
 
 Use `trycast` when:
+
 - The cast might fail at runtime
 - You want to check before using the result
 - You're implementing type guards or polymorphic patterns

--- a/packages/emitter/src/array.test.ts
+++ b/packages/emitter/src/array.test.ts
@@ -48,8 +48,8 @@ describe("Array Emission", () => {
 
     const code = emitModule(module);
 
-    // Native array syntax - inferred element type
-    expect(code).to.include("new[] { 1, 2, 3 }");
+    // Native array syntax with explicit type - number maps to double
+    expect(code).to.include("new double[] { 1, 2, 3 }");
   });
 
   it("should emit sparse array with holes", () => {
@@ -91,8 +91,8 @@ describe("Array Emission", () => {
 
     const code = emitModule(module);
 
-    // Native array syntax with default for holes
-    expect(code).to.include("new[] { 1, default, 3 }");
+    // Native array syntax with explicit type and default for holes
+    expect(code).to.include("new double[] { 1, default, 3 }");
   });
 
   it("should emit array with string elements", () => {
@@ -133,8 +133,8 @@ describe("Array Emission", () => {
 
     const code = emitModule(module);
 
-    // Native array with string elements
-    expect(code).to.include('new[] { "hello", "world" }');
+    // Native array with explicit string type
+    expect(code).to.include('new string[] { "hello", "world" }');
   });
 
   it("should emit empty array", () => {

--- a/packages/emitter/src/expressions/index.test.ts
+++ b/packages/emitter/src/expressions/index.test.ts
@@ -85,8 +85,8 @@ describe("Expression Emission", () => {
 
     const result = emitModule(module);
 
-    // Native array syntax
-    expect(result).to.include("new[] { 1, 2, 3 }");
+    // Native array syntax with explicit type
+    expect(result).to.include("new int[] { 1, 2, 3 }");
   });
 
   it("should emit template literals", () => {

--- a/packages/emitter/testcases/common/arrays/basic/ArrayLiteral.ts
+++ b/packages/emitter/testcases/common/arrays/basic/ArrayLiteral.ts
@@ -1,4 +1,6 @@
-export function createArray(): number[] {
+import { int } from "@tsonic/core/types.js";
+
+export function createArray(): int[] {
   const arr = [1, 2, 3];
   return arr;
 }

--- a/packages/emitter/testcases/common/arrays/double-array/DoubleArray.ts
+++ b/packages/emitter/testcases/common/arrays/double-array/DoubleArray.ts
@@ -1,0 +1,11 @@
+// Test that number[] correctly emits as double[]
+// This guards against regression where integer literals might incorrectly emit as int[]
+// Key invariant: number[] MUST emit double[] even when elements are integer literals
+export function createDoubleArray(): number[] {
+  const arr: number[] = [1, 2, 3];  // Integer literals, but number[] annotation → double[]
+  return arr;
+}
+
+export function returnDoubleArray(): number[] {
+  return [4, 5, 6];  // Return type provides context → double[]
+}

--- a/packages/emitter/testcases/common/arrays/double-array/config.yaml
+++ b/packages/emitter/testcases/common/arrays/double-array/config.yaml
@@ -1,0 +1,1 @@
+- DoubleArray.ts: should emit number[] as double[] with integer literals

--- a/packages/emitter/testcases/common/expected/arrays/basic/ArrayLiteral.cs
+++ b/packages/emitter/testcases/common/expected/arrays/basic/ArrayLiteral.cs
@@ -2,9 +2,9 @@ namespace TestCases.common.arrays.basic
 {
         public static class ArrayLiteral
         {
-            public static double[] createArray()
+            public static int[] createArray()
                 {
-                var arr = new[] { 1, 2, 3 };
+                var arr = new int[] { 1, 2, 3 };
                 return arr;
                 }
         }

--- a/packages/emitter/testcases/common/expected/arrays/double-array/DoubleArray.cs
+++ b/packages/emitter/testcases/common/expected/arrays/double-array/DoubleArray.cs
@@ -1,0 +1,16 @@
+namespace TestCases.common.arrays.doublearray
+{
+        public static class DoubleArray
+        {
+            public static double[] createDoubleArray()
+                {
+                var arr = new double[] { 1, 2, 3 };
+                return arr;
+                }
+
+            public static double[] returnDoubleArray()
+                {
+                return new double[] { 4, 5, 6 };
+                }
+        }
+}

--- a/packages/emitter/testcases/common/expected/arrays/multidimensional/MultiDimensional.cs
+++ b/packages/emitter/testcases/common/expected/arrays/multidimensional/MultiDimensional.cs
@@ -9,7 +9,7 @@ namespace TestCases.common.arrays.multidimensional
 
             public static double[][] createMatrix()
                 {
-                return new[] { new[] { 1, 2 }, new[] { 3, 4 } };
+                return new double[][] { new double[] { 1, 2 }, new double[] { 3, 4 } };
                 }
         }
 }

--- a/packages/emitter/testcases/common/expected/types/type-assertions/TypeAssertions.cs
+++ b/packages/emitter/testcases/common/expected/types/type-assertions/TypeAssertions.cs
@@ -17,9 +17,9 @@ namespace TestCases.common.types.typeassertions
 
                 public static readonly short shortFromLiteral = 1000;
 
-                public static readonly long longFromLiteral = 1000000;
+                public static readonly long longFromLiteral = 1000000L;
 
-                public static readonly float floatFromLiteral = 1.5;
+                public static readonly float floatFromLiteral = 1.5f;
 
                 public static readonly double doubleFromLiteral = 1.5;
 

--- a/packages/emitter/testcases/common/expected/types/variable-decls/VariableDecls.cs
+++ b/packages/emitter/testcases/common/expected/types/variable-decls/VariableDecls.cs
@@ -16,9 +16,9 @@ namespace TestCases.common.types.variabledecls
 
             public static readonly short explicitShort = 1000;
 
-            public static readonly long explicitLong = 1000000;
+            public static readonly long explicitLong = 1000000L;
 
-            public static readonly float explicitFloat = 1.5;
+            public static readonly float explicitFloat = 1.5f;
 
             public static readonly double explicitDouble = 1.5;
 
@@ -32,9 +32,9 @@ namespace TestCases.common.types.variabledecls
 
             public static readonly short assertedShort = 1000;
 
-            public static readonly long assertedLong = 1000000;
+            public static readonly long assertedLong = 1000000L;
 
-            public static readonly float assertedFloat = 1.5;
+            public static readonly float assertedFloat = 1.5f;
 
             public static readonly double assertedDouble = 42;
 
@@ -44,12 +44,12 @@ namespace TestCases.common.types.variabledecls
                 var localInferredInt = 42;
                 var localInferredString = "local";
                 var localInferredBool = true;
-                int localExplicitInt = 100;
+                var localExplicitInt = 100;
                 byte localExplicitByte = 200;
-                float localExplicitFloat = 3.14;
-                string localExplicitString = "explicit";
+                var localExplicitFloat = 3.14f;
+                var localExplicitString = "explicit";
                 var localAssertedInt = 200;
-                var localAssertedFloat = 3.14;
+                var localAssertedFloat = 3.14f;
                 var localAssertedDouble = 100;
                 }
 

--- a/packages/frontend/src/ir/validation/numeric-proof-pass.ts
+++ b/packages/frontend/src/ir/validation/numeric-proof-pass.ts
@@ -644,7 +644,28 @@ const processExpression = (
       const processedLeft = processExpression(expr.left, ctx);
       const processedRight = processExpression(expr.right, ctx);
 
-      // Infer numeric kind from processed operands
+      // Comparison operators return boolean, not numeric - skip numeric annotation
+      const comparisonOperators = new Set([
+        "<",
+        ">",
+        "<=",
+        ">=",
+        "==",
+        "!=",
+        "===",
+        "!==",
+      ]);
+
+      if (comparisonOperators.has(expr.operator)) {
+        // Comparison operators produce boolean, NOT numeric types
+        return {
+          ...expr,
+          left: processedLeft,
+          right: processedRight,
+        };
+      }
+
+      // Infer numeric kind from processed operands (only for arithmetic/bitwise ops)
       const leftKind = inferNumericKind(processedLeft, ctx);
       const rightKind = inferNumericKind(processedRight, ctx);
 

--- a/test/README.md
+++ b/test/README.md
@@ -28,6 +28,7 @@ test/
 ```
 
 The unified test runner:
+
 1. Runs `npm test` (unit tests + golden tests across all packages)
 2. Runs E2E dotnet tests (compile and execute each fixture)
 3. Runs negative tests (verify expected compilation failures)

--- a/test/fixtures/unprovable-numeric-narrowing/package-lock.json
+++ b/test/fixtures/unprovable-numeric-narrowing/package-lock.json
@@ -8,10 +8,16 @@
       "name": "unprovable-numeric-narrowing-test",
       "version": "1.0.0",
       "dependencies": {
+        "@tsonic/core": "*",
         "@tsonic/dotnet": "^0.7.4",
-        "@tsonic/globals": "^0.1.0",
-        "@tsonic/types": "^0.3.1"
+        "@tsonic/globals": "^0.1.0"
       }
+    },
+    "node_modules/@tsonic/core": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@tsonic/core/-/core-0.6.0.tgz",
+      "integrity": "sha512-GzkVRGoTdgv5F5mNMKx2TFMA2ZdtQWTnRUSTuiDPdopFDwFM6bdWyfAsq48h86Y3rh0MJOH6iSAa3uNgQI2qRg==",
+      "license": "MIT"
     },
     "node_modules/@tsonic/dotnet": {
       "version": "0.7.4",
@@ -32,12 +38,6 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/@tsonic/globals/-/globals-0.1.0.tgz",
       "integrity": "sha512-LGr1m5pi/zp/qOm0egyGjFIRGrWAusgapEUBc1XD6lfeXxY4eyXSge9eBL1bHzS4LYv4k7uW2fOR5DIvIPyd1A==",
-      "license": "MIT"
-    },
-    "node_modules/@tsonic/types": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@tsonic/types/-/types-0.3.1.tgz",
-      "integrity": "sha512-irXnopF+1PMPNUrtlSfploxEurZLPFntqd/YTCilh2uviyHS0mhMwG6u2ea6cVeAYfpw75q/EI6vbi8u7ImZCw==",
       "license": "MIT"
     }
   }


### PR DESCRIPTION
- Arrays emit `new T[]` instead of `new[]` for explicit typing
- Numeric literals get C# suffixes based on expected type:
  - long → L, uint → U, ulong → UL, float → f, decimal → m
- Thread expectedElementType through to array element expressions
- Resolve type aliases and strip nullish before determining element type
- Local variables use `var` (idiomatic C#), except byte/sbyte/short/ushort which need explicit LHS type (no C# suffix available)
- Skip numeric annotation for comparison operators (return boolean)
- Add guard test: number[] with integer literals must emit double[]
- Validate decimal literals (reject exponent/hex/binary forms)

🤖 Generated with [Claude Code](https://claude.com/claude-code)